### PR TITLE
Исправление обновления BattlEye

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -42,3 +42,4 @@ ffzap.com
 betterttv.net
 7tv.app
 7tv.io
+cdn.battleye.com


### PR DESCRIPTION
И снова пострадавший, ни в чем неповинный сайт - CDN Сервак античита BattlEye, из-за чего стало невозможно обновить античит и продолжить играть в мультиплеер в играх, которые его используют. Пример - R6 Siege, GTA Online, PUBG и т.д