### PR TITLE
Новая стратегия - FAKE TLS MOD AUTO ALT

### DIFF
--- a/general (FAKE TLS MOD AUTO ALT).bat
+++ b/general (FAKE TLS MOD AUTO ALT).bat
@@ -10,7 +10,7 @@ echo:
 set "BIN=%~dp0bin\"
 set "LISTS=%~dp0lists\"
 
-start "zapret: general (FAKE TLS MOD AUTO)" /min "%BIN%winws.exe" --wf-tcp=80,443 --wf-udp=443,50000-50100 ^
+start "zapret: general (FAKE TLS MOD AUTO ALT)" /min "%BIN%winws.exe" --wf-tcp=80,443 --wf-udp=443,50000-50100 ^
 --filter-udp=443 --hostlist="%LISTS%list-general.txt" --dpi-desync=fake --dpi-desync-repeats=11 --dpi-desync-fake-quic="%BIN%quic_initial_www_google_com.bin" --new ^
 --filter-udp=50000-50100 --filter-l7=discord,stun --dpi-desync=fake --dpi-desync-repeats=6 --new ^
 --filter-tcp=80 --hostlist="%LISTS%list-general.txt" --dpi-desync=fake,fakedsplit --dpi-desync-autottl=2 --dpi-desync-fooling=md5sig --new ^

--- a/general (FAKE TLS MOD AUTO ALT).bat
+++ b/general (FAKE TLS MOD AUTO ALT).bat
@@ -1,0 +1,20 @@
+@echo off
+chcp 65001 > nul
+:: 65001 - UTF-8
+
+cd /d "%~dp0"
+call service.bat status_zapret
+call service.bat check_updates
+echo:
+
+set "BIN=%~dp0bin\"
+set "LISTS=%~dp0lists\"
+
+start "zapret: general (FAKE TLS MOD AUTO)" /min "%BIN%winws.exe" --wf-tcp=80,443 --wf-udp=443,50000-50100 ^
+--filter-udp=443 --hostlist="%LISTS%list-general.txt" --dpi-desync=fake --dpi-desync-repeats=11 --dpi-desync-fake-quic="%BIN%quic_initial_www_google_com.bin" --new ^
+--filter-udp=50000-50100 --filter-l7=discord,stun --dpi-desync=fake --dpi-desync-repeats=6 --new ^
+--filter-tcp=80 --hostlist="%LISTS%list-general.txt" --dpi-desync=fake,fakedsplit --dpi-desync-autottl=2 --dpi-desync-fooling=md5sig --new ^
+--filter-tcp=443 --hostlist="%LISTS%list-general.txt" --dpi-desync=split --dpi-desync-split-pos=1 --dpi-desync-autottl --dpi-desync-fooling=badseq --dpi-desync-repeats=8 --dpi-desync-fake-tls-mod=rnd,dupsid,sni=www.google.com --new ^
+--filter-udp=443 --ipset="%LISTS%ipset-cloudflare.txt" --dpi-desync=fake --dpi-desync-repeats=11 --dpi-desync-fake-quic="%BIN%quic_initial_www_google_com.bin" --new ^
+--filter-tcp=80 --ipset="%LISTS%ipset-cloudflare.txt" --dpi-desync=fake,fakedsplit --dpi-desync-autottl=2 --dpi-desync-fooling=md5sig --new ^
+--filter-tcp=443 --ipset="%LISTS%ipset-cloudflare.txt" --dpi-desync=split --dpi-desync-split-pos=1 --dpi-desync-autottl --dpi-desync-fooling=badseq --dpi-desync-repeats=8


### PR DESCRIPTION
По глупости закрыл свой pull request - https://github.com/Flowseal/zapret-discord-youtube/pull/2736

Постараюсь объяснить вкратце. При прошлых FAKE TLS MOD стратегиях, увидел что некоторые сайты стали грузить очень долго, причем - без интерфейса, оказалось что это вызывала ошибка - ERR_SSL_PROTOCOL_ERROR, из-за чего ломалось все, и эта стратегия - эдакий комбайн из тех решений, которые существуют, и с ним данной ошибки - уже не возникает, да и мало-ли, может кому-то поможет