### PR TITLE
Добавить адреса SoundCloud в list-general.txt

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -1,3 +1,5 @@
+soundcloud.com
+sndcdn.com
 cloudflare-ech.com
 dis.gd
 discord-attachments-uploads-prd.storage.googleapis.com

--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -1,3 +1,4 @@
+soundcloud.cloud
 soundcloud.com
 sndcdn.com
 cloudflare-ech.com


### PR DESCRIPTION
Для справки: 22 мая дополнительно умер sndcdn.com - раньше для обхода достаточно было основного домена