### PR TITLE
Добавить адрес загрузчика Neoforge в list-general.txt

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -42,3 +42,4 @@ ffzap.com
 betterttv.net
 7tv.app
 7tv.io
+maven.neoforged.net


### PR DESCRIPTION
Недавно возникла проблема с работой загрузчика Neoforge (модлоадер для Minecraft). После проверки выяснилось, что добавление **maven.neoforged.net** в конфигурацию решает эту проблему.

Этот пул-реквест вносит необходимые изменения.