### PR TITLE
paths limbus company

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -42,3 +42,8 @@ ffzap.com
 betterttv.net
 7tv.app
 7tv.io
+downloadcommon.limbuscompanycdn.org
+download.limbuscompanycdn.org
+downloadfmod.limbuscompanycdn.org
+presence.limbuscompanyapi.com
+www.limbuscompanyapi.com


### PR DESCRIPTION
Recently, game "limbus company"  was also blocked. I've added the work recovery paths that Reimu Fumo found.