### PR TITLE
Расширение доменов Google для обхода в list-general.txt

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -22,6 +22,8 @@ discordmerch.com
 discordpartygames.com
 discordsays.com
 discordsez.com
+google.ru
+gstatic.com
 yt3.ggpht.com
 yt4.ggpht.com
 yt3.googleusercontent.com


### PR DESCRIPTION
`gstatic.com` - используется как минимум для загрузки .pdf в Google Drive (пример: [тык](https://drive.google.com/file/d/1VAX4rLPlk74eGWtQFvHWyqtLD8lHhhcp/view))

> [!NOTE]
> Без обхода загружается только первая страница документа в виде картинки - остальные продолжают безрезультатно скачиваться в фоне.

`google.ru` - обычный поиск гугла с .ru доменом, перенаправляет на google.com