### PR TITLE
Небольшое исправление вывода имени ранее установленного сервиса

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -63,7 +63,7 @@ goto menu
 :service_status
 cls
 chcp 437 > nul
-for /f "tokens=3*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do echo Service strategy installed from "%%A %%B"
+for /f "tokens=2*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do echo Service strategy installed from "%%B"
 call :test_service zapret
 call :test_service WinDivert
 


### PR DESCRIPTION
`"%%A %%B"` при `"tokens=3*"` выводило пробел при значении без пробела.

Например, значение "general" выводилось как "general ", хотя для значений с пробелом, таких как "general (ALT)", всё было нормально, то есть "general (ALT)".