### PR TITLE
Улучшение системы обновления, что бы она не мешала запуску запрета

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -11,6 +11,10 @@ if "%~1"=="check_updates" (
     call :service_check_updates soft
     exit /b
 )
+if "%~1"=="start_update" (
+    call :service_start_update soft
+    exit /b
+)
 
 if "%~1"=="load_game_filter" (
     call :game_switch_status
@@ -63,7 +67,7 @@ goto menu
 :service_status
 cls
 chcp 437 > nul
-for /f "tokens=2*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do echo Service strategy installed from "%%B"
+for /f "tokens=3*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do echo Service strategy installed from "%%A %%B"
 call :test_service zapret
 call :test_service WinDivert
 
@@ -251,6 +255,15 @@ goto menu
 
 :: CHECK UPDATES =======================
 :service_check_updates
+if "%1"=="soft" (
+start /b service start_update
+exit /b
+)
+goto :service_start_update
+
+
+:service_start_update
+
 chcp 437 > nul
 cls
 
@@ -266,7 +279,7 @@ for /f "delims=" %%A in ('powershell -command "(Invoke-WebRequest -Uri \"%GITHUB
 if not defined GITHUB_VERSION (
     echo Warning: failed to fetch the latest version. Check your internet connection. This warning does not affect the operation of zapret
     pause
-    if "%1"=="soft" exit /b 
+    if "%1"=="soft" exit 
     goto menu
 )
 
@@ -274,7 +287,7 @@ if not defined GITHUB_VERSION (
 if "%LOCAL_VERSION%"=="%GITHUB_VERSION%" (
     echo Latest version installed: %LOCAL_VERSION%
     
-    if "%1"=="soft" exit /b
+    if "%1"=="soft" exit 
     pause
     goto menu
 ) 
@@ -293,9 +306,10 @@ if /i "%CHOICE%"=="Y" (
 )
 
 
-if "%1"=="soft" exit /b
+if "%1"=="soft" exit 
 pause
 goto menu
+
 
 
 :: DIAGNOSTICS =========================
@@ -519,7 +533,7 @@ chcp 437 > nul
 cls
 
 set "listFile=%~dp0lists\ipset-all.txt"
-set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt"
+set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/lists/ipset-all.txt"
 
 echo Updating ipset-all...
 

--- a/service.bat
+++ b/service.bat
@@ -67,7 +67,7 @@ goto menu
 :service_status
 cls
 chcp 437 > nul
-for /f "tokens=3*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do echo Service strategy installed from "%%A %%B"
+for /f "tokens=2*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do echo Service strategy installed from "%%B"
 call :test_service zapret
 call :test_service WinDivert
 
@@ -533,7 +533,7 @@ chcp 437 > nul
 cls
 
 set "listFile=%~dp0lists\ipset-all.txt"
-set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/lists/ipset-all.txt"
+set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt"
 
 echo Updating ipset-all...
 


### PR DESCRIPTION
### Проблема
Каждый раз при запуске zapretа без обновления было необходимо переключатся на окно с командной строкой, переключать раскладку, прописывать N, переключать раскладку обратно, нажимать энтр, переключаться в браузер.

После моих исправлений достаточно нажать на крестик окна с обновлением.

### Что изменено?

Система обновления и zapret запускаются паралельно, двумя разными независимыми процессами.


