### PR TITLE
Disable GameFilter by setting port number to 12 (unassigned by IANA)

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -426,7 +426,7 @@ if exist "%gameFlagFile%" (
     set "GameFilter=1024-65535"
 ) else (
     set "GameFilterStatus=disabled"
-    set "GameFilter=0"
+    set "GameFilter=540"
 )
 exit /b
 

--- a/service.bat
+++ b/service.bat
@@ -426,7 +426,7 @@ if exist "%gameFlagFile%" (
     set "GameFilter=1024-65535"
 ) else (
     set "GameFilterStatus=disabled"
-    set "GameFilter=540"
+    set "GameFilter=12"
 )
 exit /b
 


### PR DESCRIPTION
Несколько пользователей пожаловались на проблемы с подключением к WiFi, если zapret установлен как сервис (#4236 , #4245). А также с проводным подключением после выхода компа из режима сна. 

Есть предположение, что это связано с установлением `set "GameFilter=0"` и последующим использованием нулевого значения при запуске `winws`. Не совсем понятно, почему это происходит, т.к. в теории порты tcp/0 и udp/0 не должны использоваться. 

Не придумал ничего лучше, чем поменять 0 на какой-нибудь редко используемый порт. Выбрал номер порта 540 (uucp), т.к. не должен использоваться в Windows.