### PR TITLE
Change failed update message

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -293,8 +293,8 @@ for /f "delims=" %%A in ('powershell -command "(Invoke-WebRequest -Uri \"%GITHUB
 
 :: Error handling
 if not defined GITHUB_VERSION (
-    echo Warning: failed to fetch the latest version. Check your internet connection. This warning does not affect the operation of zapret
-    pause
+    echo Warning: failed to fetch the latest version. This warning does not affect the operation of zapret
+    timeout /T 9
     if "%1"=="soft" exit 
     goto menu
 )


### PR DESCRIPTION
Может не обновляться, если URL заблокирован, или если интернет поломан. Люди нервничают, что появляются буковки на экране. 

Убрал "Check your internet connection" и заменил pause на ожидание с обратным отсчетом секунд.