### PR TITLE
Добавить speedtest.net в list-general.txt

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -44,3 +44,4 @@ ffzap.com
 betterttv.net
 7tv.app
 7tv.io
+speedtest.net


### PR DESCRIPTION
Добавил домен speedtest.net в список блокировки, так как этот сервис также заблокирован в РФ.