### PR TITLE
Вывод сервисов VPN в диагностиках

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -451,7 +451,14 @@ echo:
 :: VPN
 sc query | findstr /I "VPN" > nul
 if !errorlevel!==0 (
-    call :PrintYellow "[?] Some VPN services found. Some VPNs can conflict with zapret"
+    for /f "tokens=2 delims=:" %%A in ('sc query ^|^ findstr /I "VPN"') do (
+        if not defined VPN_SERVICES (
+            set "VPN_SERVICES=!VPN_SERVICES!%%A"
+        ) else (
+            set "VPN_SERVICES=!VPN_SERVICES!,%%A"
+        )
+    )
+    call :PrintYellow "[?] VPN services found:!VPN_SERVICES!. Some VPNs can conflict with zapret"
     call :PrintYellow "Make sure that all VPNs are disabled"
 ) else (
     call :PrintGreen "VPN check passed"

--- a/service.bat
+++ b/service.bat
@@ -453,7 +453,7 @@ sc query | findstr /I "VPN" > nul
 if !errorlevel!==0 (
     for /f "tokens=2 delims=:" %%A in ('sc query ^|^ findstr /I "VPN"') do (
         if not defined VPN_SERVICES (
-            set "VPN_SERVICES=%%A"
+            set "VPN_SERVICES=!VPN_SERVICES!%%A"
         ) else (
             set "VPN_SERVICES=!VPN_SERVICES!,%%A"
         )

--- a/service.bat
+++ b/service.bat
@@ -453,7 +453,7 @@ sc query | findstr /I "VPN" > nul
 if !errorlevel!==0 (
     for /f "tokens=2 delims=:" %%A in ('sc query ^|^ findstr /I "VPN"') do (
         if not defined VPN_SERVICES (
-            set "VPN_SERVICES=!VPN_SERVICES!%%A"
+            set "VPN_SERVICES=%%A"
         ) else (
             set "VPN_SERVICES=!VPN_SERVICES!,%%A"
         )


### PR DESCRIPTION
Видел пару issue, где человек не понимал, на какие VPN жалуется диагностика.
Будет лучше, если человек сразу понимал, какие VPN надо выключить, без команд в командной строке, или создавания тут issue.

Перечисляет все найденные сервисы VPN через запятую.