### PR TITLE
Исправление дублирования имён сервисов в проверке на VPN

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -471,6 +471,7 @@ if not exist "%BIN_PATH%\*.sys" (
 echo:
 
 :: VPN
+set "VPN_SERVICES="
 sc query | findstr /I "VPN" > nul
 if !errorlevel!==0 (
     for /f "tokens=2 delims=:" %%A in ('sc query ^|^ findstr /I "VPN"') do (

--- a/service.bat
+++ b/service.bat
@@ -474,7 +474,7 @@ echo:
 set "VPN_SERVICES="
 sc query | findstr /I "VPN" > nul
 if !errorlevel!==0 (
-    for /f "tokens=2 delims=:" %%A in ('sc query ^|^ findstr /I "VPN"') do (
+    for /f "tokens=2 delims=:" %%A in ('sc query ^| findstr /I "VPN"') do (
         if not defined VPN_SERVICES (
             set "VPN_SERVICES=!VPN_SERVICES!%%A"
         ) else (


### PR DESCRIPTION
Если несколько раз проводить диагностику в одной сессии, имена сервисов VPN дублировались:
<img width="960" height="57" alt="есть только 1 настоящий vpn_test_01" src="https://github.com/user-attachments/assets/ca925945-d8b5-41ae-8138-fc059dc13da7" />
В переменную `VPN_SERVICES` добавлялись имена сервисов, но старые не удалялись. Исправил это очисткой этой переменной.

Также убран ненужный символ `^`.