### PR TITLE
fix test window closing on error

### DIFF
--- a/utils/test zapret.ps1
+++ b/utils/test zapret.ps1
@@ -333,6 +333,8 @@ if (Test-ZapretServiceConflict) {
 if ($hasErrors) {
     Write-Host ""
     Write-Host "Fix the errors above and rerun." -ForegroundColor Yellow
+    Write-Host "Press any key to exit..." -ForegroundColor Yellow
+    [void][System.Console]::ReadKey($true)
     exit 1
 }
 
@@ -480,6 +482,8 @@ Write-Host "[WARNING] Tests may take several minutes to complete. Please wait...
 # Ensure we have configs to run
 if (-not $batFiles -or $batFiles.Count -eq 0) {
     Write-Host "[ERROR] No general*.bat files found" -ForegroundColor Red
+    Write-Host "Press any key to exit..." -ForegroundColor Yellow
+    [void][System.Console]::ReadKey($true)
     exit 1
 }
 


### PR DESCRIPTION
окно с тестами закрывалось автоматически если был установлен сервис или не установлен курл итд итп и пользовать не успевал увидеть в чем проблема