### PR TITLE
Fix best config selection logic

### DIFF
--- a/utils/test zapret.ps1
+++ b/utils/test zapret.ps1
@@ -753,12 +753,14 @@ try {
     $bestConfig = $null
     $maxScore = 0
     foreach ($config in $analytics.Keys) {
-        $a = $analytics[$config]
-        $score = $a.OK
-        $score -gt $maxScore
+    $a = $analytics[$config]
+    $score = $a.OK
+    if ($score -gt $maxScore) {
         $maxScore = $score
         $bestConfig = $config
     }
+}
+
     Write-Host ""
     Write-Host "Best config: $bestConfig" -ForegroundColor Green
     Write-Host ""


### PR DESCRIPTION
Fixed missing conditional in best config selection loop. Previously, the comparison result ($score -gt $maxScore) was ignored, causing the last config in the hashtable to be selected regardless of score.