### PR TITLE
Добавление доменов GitHub'a в list-general.txt

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -41,6 +41,12 @@ discordsez.com
 discordstatus.com
 frankerfacez.com
 ffzap.com
+github.com
+github.io
+github.blog
+github.community
+githubassets.com
+githubusercontent.com
 betterttv.net
 7tv.app
 7tv.io


### PR DESCRIPTION
В обсуждении #8333 было замечено, что у пользователя возникают проблемы с доступом к GitHub. От многих знакомых тоже поступали такие жалобы.

Через время вроде все начинает работать нормально, но не стабильная работа может помешать и воовсе потом зайти сюда.
Я собрал полный список необходимых доменов для корректной работы сайта, включая CDN и хранилища контента. Это обеспечит работу как самого интерфейса, так и скачивание релизов/ассетов.

UPD: знаю что супер лёгкий пулл реквест, мне об этом писать не надо, говорю заранее) но последними днями это могло затерятся и быть не таким важным на фоне последних блокировок и замедлений.
