### PR TITLE
Исправлена сортировка названий файлов стратегий по номерам

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -188,13 +188,10 @@ set "LISTS_PATH=%~dp0lists\"
 :: Searching for .bat files in current folder, except files that start with "service"
 echo Pick one of the options:
 set "count=0"
-for %%f in (*.bat) do (
-    set "filename=%%~nxf"
-    if /i not "!filename:~0,7!"=="service" (
-        set /a count+=1
-        echo !count!. %%f
-        set "file!count!=%%f"
-    )
+for /f "delims=" %%F in ('powershell -Command "Get-ChildItem -Filter '*.bat' | Where-Object { $_.Name -notlike 'service*' } | Sort-Object { [Regex]::Replace($_.Name, '\d+', { $args[0].Value.PadLeft(8, '0') }) } | ForEach-Object { $_.Name }"') do (
+    set /a count+=1
+    echo !count!. %%F
+    set "file!count!=%%F"
 )
 
 :: Choosing file

--- a/utils/test zapret.ps1
+++ b/utils/test zapret.ps1
@@ -384,7 +384,7 @@ $dpiTargets = Build-DpiTargets -CustomUrl $dpiCustomUrl
 # Config
 $targetDir = $rootDir
 if (-not $targetDir) { $targetDir = Split-Path -Parent $MyInvocation.MyCommand.Path }
-$batFiles = Get-ChildItem -Path $targetDir -Filter "*.bat" | Where-Object { $_.Name -notlike "service*" } | Sort-Object Name
+$batFiles = Get-ChildItem -Path $targetDir -Filter "*.bat" | Where-Object { $_.Name -notlike "service*" } | Sort-Object { [Regex]::Replace($_.Name, "\d+", { $args[0].Value.PadLeft(8, "0") }) }
 
 $globalResults = @()
 


### PR DESCRIPTION
Так как Windows по умолчанию использует сортировку в формате ASCIIbetical, то пользователи могли заметить то, что "ALT2" идёт после "ALT11", а не после "ALT1". Поэтому я решил попробовать исправить это, но немножко "подвинуть" такую сортировку в правильном направлении, используя Regex. То есть, это до сих пор не является сортировкой в алфавитном порядке.

Был вариант с переименованием самих файлов стратегий, но я подумал, что это может быть не самой лучшей идеей в плане дальнейшей поддержки стратегий (но я не сильно в это углублялся, поэтому точно не скажу). Была идея просто добавить нолик слева от номера стратегии, если этот самый номер был по значению меньше 10, то есть: "ALT01", "ALT02", "ALT10", "ALT11". Этот вариант бы сработал, так как в ASCII `0` < `1`. Его я примерно и реализовал в скриптах.

Единственная проблема текущей реализации - из-за вызова PowerShell будет заметно, что названия выводятся дольше.

Я бы хотел узнать у @Flowseal, если переименовывать файлы можно. А пока я остановился на варианте с изменением логики сортировки в скриптах `service.bat` и `utils/test zapret.ps1`.