### PR TITLE
Убрана лишняя новая строка в меню диагностики в `service.bat`

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -488,8 +488,8 @@ echo:
 set "BIN_PATH=%~dp0bin\"
 if not exist "%BIN_PATH%\*.sys" (
     call :PrintRed "WinDivert64.sys file NOT found."
+    echo:
 )
-echo:
 
 :: VPN
 set "VPN_SERVICES="


### PR DESCRIPTION
В меню диагностики перед проверкой VPN есть проверка на наличие файла `WinDivert64.sys`, в которой создаётся новая строка независимо от выполнения условия. То есть, если условие не проходит проверку, то создаётся лишняя новая строка.

<img alt="Дополнительная новая строка" src="https://github.com/user-attachments/assets/e915d056-2823-4abb-b002-ca2b5fbd459b" />
