### PR TITLE
Update copyright years in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2016-2025 bol-van
-Copyright (c) 2024-2025 Flowseal
+Copyright (c) 2016-2026 bol-van
+Copyright (c) 2024-2026 Flowseal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright years in the `LICENSE.txt` file to extend coverage through 2026.