### PR TITLE
denchisoft.com (VTube Studio) in to list-general.txt

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -45,3 +45,4 @@ betterttv.net
 7tv.app
 7tv.io
 localizeapi.com
+denchisoft.com


### PR DESCRIPTION
Домен denchisoft.com относится к популярному приложению VTube Studio (https://store.steampowered.com/app/1325860/VTube_Studio/) которое витуберы используют для отрисовки своих моделек.

Добавление домена в лист позволяет починить функцию коллабораций которая использует внутренний сервис VNet для обьединения моделек, без нее модельки во время коллаборации просто не загружаются на сервис.