### PR TITLE
"Аддоны" для Zapret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /utils/test results
+/addons


### PR DESCRIPTION
## Зачем оно нужно: 
#### После каждого глобального обновления стратегий мне приходится вручную дописывать в конфиги нужные стартегии. Если основная стратегия дохнет - надо дописывать в другой. И чёто я подустал от постоянных "дописываний" и придумал как это можно решить. Так-же  это пригодиться когда люди делятся обходами под конкретную игру они скидывают весь конфиг что может повлиять на работу остальных ресурсов.

---

# Суть PR'a: 
При установке любой стратегии к нему будут добавляться стратегии из всех `.bypass` файлов в папке `addons`. 

Пример файла `addons/minecraft.bypass`:
```
--new
	--filter-tcp=25565 --dpi-desync-any-protocol=1 --dpi-desync-cutoff=n5...
```



В итоге к выбранной стратегии будут добавляться ещё и эта, кол-во "аддонов" не ограничено. В теории можно будет сделать ещё и репозиторий с аддонами.

> P.S. Я не сделал поддержку аддонов для случаев когда люди просто запускают general.bat (без сервиса), т.к. считаю что трогать работу основной стратегии не стоит.

Если людям зайдет - могу допилить что понадобиться. 
Всех обнял ;) 