### PR TITLE
Allow returning to main menu by selecting 0 from Install Service

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -208,6 +208,8 @@ for /f "delims=" %%F in ('powershell -NoProfile -Command "Get-ChildItem -Literal
     echo !count!. %%F
     set "file!count!=%%F"
 )
+echo 0. Return to main menu
+echo ----------------------------------------
 
 :: Choosing file
 set "choice="
@@ -218,9 +220,14 @@ if "!choice!"=="" (
     goto menu
 )
 
+if "!choice!"=="0" (
+    echo Returning to main menu...
+    goto menu
+)
+
 set "selectedFile=!file%choice%!"
 if not defined selectedFile (
-    echo Invalid choice, exiting...
+    echo Invalid choice, returning to menu...
     pause
     goto menu
 )


### PR DESCRIPTION
- Previously, returning to main menu required pressing Enter twice.
- To go back you need to select "0".
- Added visual separation before "Input file index (number): ".