### PR TITLE
Добавление адресов steam в list-exclude.txt

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -29,3 +29,16 @@ lesta.ru
 korabli.su
 tanksblitz.ru
 reg.ru
+steampowered.com
+steamcommunity.com
+steamcontent.com
+steamusercontent.com
+steamstatic.com
+steamgames.com
+steam-chat.com
+steampipe.akamaized.net
+steamcloudsweden.blob.core.windows.net
+blob.core.windows.net
+azureedge.net
+akamaihd.net
+akamaized.net


### PR DESCRIPTION
Без адресов не работают комьюнити‑сервисы стима, такие как торговая площадка, мастерская, профили, а также не работает встроенный в стим браузер.