### PR TITLE
Улучшенный список в "Install Service"

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -230,15 +230,6 @@ set "LISTS_PATH=%~dp0lists\"
 echo Pick one of the options:
 echo ----------------------------------------
 
-set "currentStrategy="
-for /f "tokens=2*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do (
-    set "currentStrategy=%%B"
-)
-if defined currentStrategy (
-    echo Current installed strategy: !currentStrategy!
-    echo.
-)
-
 set "count=0"
 for /f "tokens=1,2,* delims=|" %%A in ('powershell -NoProfile -Command ^
     "$files = Get-ChildItem -LiteralPath '.' -Filter '*.bat' | Where-Object { $_.Name -notlike 'service*' } | Sort-Object { [Regex]::Replace($_.Name, '(\d+)', { $args[0].Value.PadLeft(8, '0') }) };" ^
@@ -248,8 +239,7 @@ for /f "tokens=1,2,* delims=|" %%A in ('powershell -NoProfile -Command ^
     "foreach ($group in $groups.GetEnumerator()) {" ^
     "if ($group.Value.Count -eq 0) { continue };" ^
     "'GROUP|' + $group.Key;" ^
-    "$sorted = $group.Value | Sort-Object @{Expression={ if ([regex]::IsMatch($_, '(?i)\bALT(?:\d+)?\b')) { 1 } else { 0 } }}, @{Expression={ $m = [regex]::Match($_, '(?i)\bALT(\d+)\b'); if ($m.Success) { [int]$m.Groups[1].Value } elseif ([regex]::IsMatch($_, '(?i)\bALT\b')) { 0 } else { -1 } }}, @{Expression={ [Regex]::Replace($_, '(\d+)', { $args[0].Value.PadLeft(8, '0') }) }};" ^
-    "foreach ($name in $sorted) { $i++; 'ITEM|' + $i + '|' + $name }" ^
+    "foreach ($name in $group.Value) { $i++; 'ITEM|' + $i + '|' + $name }" ^
     "}"') do (
     if /i "%%A"=="GROUP" (
         echo.


### PR DESCRIPTION
- **Разбил стратегии на категории (BASE, SIMPLE FAKE и FAKE TLS AUTO) и сделал более красивое меню выбора стратегий под кнопкой 1 в "service.bat"**

(поначалу хотел сделать чтобы названия стратегий без alt были первее остальных с alt (динамично) и с отображением текущей запущенной стратегии, но потом передумал и обратно вернул вторым коммитом, в итоге из изменений только те которые написаны выше)

<img width="978" height="512" alt="изображение" src="https://github.com/user-attachments/assets/55042b98-ee39-4ab7-a9c7-335eda89e1cd" />
