### PR TITLE
Добавление marketplace.visualstudio.com в исключения

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -33,3 +33,4 @@ lesta.ru
 korabli.su
 tanksblitz.ru
 reg.ru
+marketplace.visualstudio.com


### PR DESCRIPTION
добавил сайт marketplace.visualstudio.com, необходимый сайт для работы расширений Visual Studio Code (ибо без него вылазит ошибка "failed to fetch"