### PR TITLE
Удаление ненужного парсинга переменной %GameFilter% в Install Service

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -298,8 +298,6 @@ for /f "tokens=*" %%a in ('type "!selectedFile!"') do (
                     ) else (
                         set "arg=\!QUOTE!%~dp0!arg!\!QUOTE!"
                     )
-                ) else if "!arg:~0,12!" EQU "%%GameFilter%%" (
-                    set "arg=%GameFilter%"
                 ) else if "!arg:~0,15!" EQU "%%GameFilterTCP%%" (
                     set "arg=%GameFilterTCP%"
                 ) else if "!arg:~0,15!" EQU "%%GameFilterUDP%%" (


### PR DESCRIPTION
После разделения GameFilter на режимы, в парсере стратегии в Install Service остался парсинг неопределенной переменной `%GameFilter%`.