### PR TITLE
fix: сделать обновления IPSet и hosts атомарными

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -810,18 +810,11 @@ goto menu
 :ipset_switch_status
 chcp 437 > nul
 
-set "listFile=%~dp0lists\ipset-all.txt"
-for /f %%i in ('type "%listFile%" 2^>nul ^| find /c /v ""') do set "lineCount=%%i"
-
-if !lineCount!==0 (
-    set "IPsetStatus=any"
-) else (
-    findstr /R "^203\.0\.113\.113/32$" "%listFile%" >nul
-    if !errorlevel!==0 (
-        set "IPsetStatus=none"
-    ) else (
-        set "IPsetStatus=loaded"
-    )
+set "IPsetStatus=unknown"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0utils\service-state.ps1" get-ipset-status 2^>nul`) do (
+    if /I "%%i"=="loaded" set "IPsetStatus=loaded"
+    if /I "%%i"=="none" set "IPsetStatus=none"
+    if /I "%%i"=="any" set "IPsetStatus=any"
 )
 exit /b
 
@@ -830,42 +823,10 @@ exit /b
 chcp 437 > nul
 cls
 
-set "listFile=%~dp0lists\ipset-all.txt"
-set "backupFile=%listFile%.backup"
-
-if "%IPsetStatus%"=="loaded" (
-    echo Switching to none mode...
-    
-    if not exist "%backupFile%" (
-        ren "%listFile%" "ipset-all.txt.backup"
-    ) else (
-        del /f /q "%backupFile%"
-        ren "%listFile%" "ipset-all.txt.backup"
-    )
-    
-    >"%listFile%" (
-        echo 203.0.113.113/32
-    )
-    
-) else if "%IPsetStatus%"=="none" (
-    echo Switching to any mode...
-    
-    >"%listFile%" (
-        rem Creating empty file
-    )
-    
-) else if "%IPsetStatus%"=="any" (
-    echo Switching to loaded mode...
-    
-    if exist "%backupFile%" (
-        del /f /q "%listFile%"
-        ren "%backupFile%" "ipset-all.txt"
-    ) else (
-        echo Error: no backup to restore. Update list from service menu first
-        pause
-        goto menu
-    )
-    
+echo Switching IPSet mode...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0utils\service-state.ps1" switch-ipset
+if %errorlevel% neq 0 (
+    call :PrintRed "Failed to switch IPSet mode"
 )
 
 pause
@@ -877,24 +838,13 @@ goto menu
 chcp 437 > nul
 cls
 
-set "listFile=%~dp0lists\ipset-all.txt"
 set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt"
 
 echo Updating ipset-all...
-
-if exist "%SystemRoot%\System32\curl.exe" (
-    curl -L -o "%listFile%" "%url%"
-) else (
-    powershell -NoProfile -Command ^
-        "$url = '%url%';" ^
-        "$out = '%listFile%';" ^
-        "$dir = Split-Path -Parent $out;" ^
-        "if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir | Out-Null };" ^
-        "$res = Invoke-WebRequest -Uri $url -TimeoutSec 10 -UseBasicParsing;" ^
-        "if ($res.StatusCode -eq 200) { $res.Content | Out-File -FilePath $out -Encoding UTF8 } else { exit 1 }"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0utils\service-state.ps1" update-ipset "%url%"
+if %errorlevel% neq 0 (
+    call :PrintRed "Failed to update IPSet list"
 )
-
-echo Finished
 
 pause
 goto menu
@@ -907,59 +857,10 @@ cls
 
 set "hostsFile=%SystemRoot%\System32\drivers\etc\hosts"
 set "hostsUrl=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/hosts"
-set "tempFile=%TEMP%\zapret_hosts.txt"
-set "needsUpdate=0"
-
-echo Checking hosts file...
-
-if exist "%SystemRoot%\System32\curl.exe" (
-    curl -L -s -o "%tempFile%" "%hostsUrl%"
-) else (
-    powershell -NoProfile -Command ^
-        "$url = '%hostsUrl%';" ^
-        "$out = '%tempFile%';" ^
-        "$res = Invoke-WebRequest -Uri $url -TimeoutSec 10 -UseBasicParsing;" ^
-        "if ($res.StatusCode -eq 200) { $res.Content | Out-File -FilePath $out -Encoding UTF8 } else { exit 1 }"
-)
-
-if not exist "%tempFile%" (
-    call :PrintRed "Failed to download hosts file from repository"
-    call :PrintYellow "Copy hosts file manually from %hostsUrl%"
-    pause
-    goto menu
-)
-
-set "firstLine="
-set "lastLine="
-for /f "usebackq delims=" %%a in ("%tempFile%") do (
-    if not defined firstLine (
-        set "firstLine=%%a"
-    )
-    set "lastLine=%%a"
-)
-
-findstr /C:"!firstLine!" "%hostsFile%" >nul 2>&1
-if !errorlevel! neq 0 (
-    echo First line from repository not found in hosts file
-    set "needsUpdate=1"
-)
-
-findstr /C:"!lastLine!" "%hostsFile%" >nul 2>&1
-if !errorlevel! neq 0 (
-    echo Last line from repository not found in hosts file
-    set "needsUpdate=1"
-)
-
-if "%needsUpdate%"=="1" (
-    echo:
-    call :PrintYellow "Hosts file needs to be updated"
-    call :PrintYellow "Please manually copy the content from the downloaded file to your hosts file"
-    
-    start notepad "%tempFile%"
-    explorer /select,"%hostsFile%"
-) else (
-    call :PrintGreen "Hosts file is up to date"
-    if exist "%tempFile%" del /f /q "%tempFile%"
+echo Updating hosts file...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0utils\service-state.ps1" update-hosts "%hostsUrl%" "%hostsFile%"
+if %errorlevel% neq 0 (
+    call :PrintRed "Failed to update hosts file"
 )
 
 echo:

--- a/utils/service-state.ps1
+++ b/utils/service-state.ps1
@@ -1,0 +1,788 @@
+param(
+    [Parameter(Position = 0)]
+    [string]$CommandName,
+
+    [Parameter(Position = 1)]
+    [string]$RootPath,
+
+    [Parameter(Position = 2)]
+    [string]$Argument1,
+
+    [Parameter(Position = 3)]
+    [string]$Argument2
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = "Stop"
+
+if ($RootPath) {
+    $trimmedRootPath = $RootPath.Trim()
+    if ($trimmedRootPath.Length -ge 2 -and $trimmedRootPath.StartsWith('"') -and $trimmedRootPath.EndsWith('"')) {
+        $trimmedRootPath = $trimmedRootPath.Substring(1, $trimmedRootPath.Length - 2)
+    }
+
+    if ($trimmedRootPath -match '^[a-z][a-z0-9+\.-]*://' -or $trimmedRootPath -match '^[a-z]+:[^\\/]') {
+        $Argument2 = $Argument1
+        $Argument1 = $RootPath
+        $RootPath = $null
+    } else {
+        $RootPath = $trimmedRootPath
+    }
+}
+
+if (-not (Get-Variable -Name ZapretRootDir -Scope Script -ErrorAction SilentlyContinue)) {
+    if ($RootPath) {
+        $script:ZapretRootDir = [System.IO.Path]::GetFullPath($RootPath)
+    } else {
+        $script:ZapretRootDir = Split-Path -Parent $PSScriptRoot
+    }
+}
+
+$script:DummyIpsetEntry = "203.0.113.113/32"
+$script:ManagedHostsBegin = "# BEGIN zapret-discord-youtube"
+$script:ManagedHostsEnd = "# END zapret-discord-youtube"
+
+function Get-Utf8NoBomEncoding {
+    New-Object System.Text.UTF8Encoding($false)
+}
+
+function Ensure-Directory {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function New-TemporaryPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Directory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Prefix
+    )
+
+    Ensure-Directory -Path $Directory
+    Join-Path $Directory ("{0}.{1}.tmp" -f $Prefix, ([guid]::NewGuid().ToString("N")))
+}
+
+function Get-StagingDirectory {
+    $baseTemp = $env:TEMP
+    if ([string]::IsNullOrWhiteSpace($baseTemp)) {
+        $baseTemp = [System.IO.Path]::GetTempPath()
+    }
+
+    $stagingDirectory = Join-Path $baseTemp "zapret-discord-youtube"
+    Ensure-Directory -Path $stagingDirectory
+
+    return $stagingDirectory
+}
+
+function Read-FileText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (Test-Path $Path -PathType Leaf) {
+        return [System.IO.File]::ReadAllText($Path)
+    }
+
+    return ""
+}
+
+function Normalize-LineEndings {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    if ($null -eq $Text) {
+        return ""
+    }
+
+    return (($Text -replace "`r`n", "`n") -replace "`r", "`n")
+}
+
+function Normalize-ComparableText {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    return (Normalize-LineEndings -Text $Text).TrimEnd("`n")
+}
+
+function Split-NormalizedLines {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    $normalized = Normalize-LineEndings -Text $Text
+    if ($normalized.Length -eq 0) {
+        return @()
+    }
+
+    return @($normalized -split "`n", -1)
+}
+
+function Trim-BlankEdgeLines {
+    param(
+        [string[]]$Lines
+    )
+
+    if ($null -eq $Lines -or $Lines.Count -eq 0) {
+        return @()
+    }
+
+    $start = 0
+    $end = $Lines.Count - 1
+
+    while ($start -le $end -and [string]::IsNullOrWhiteSpace($Lines[$start])) {
+        $start++
+    }
+
+    while ($end -ge $start -and [string]::IsNullOrWhiteSpace($Lines[$end])) {
+        $end--
+    }
+
+    if ($start -gt $end) {
+        return @()
+    }
+
+    return @($Lines[$start..$end])
+}
+
+function Get-ExactLineIndexes {
+    param(
+        [string[]]$Lines,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $indexes = @()
+    if ($null -eq $Lines) {
+        return $indexes
+    }
+
+    for ($i = 0; $i -lt $Lines.Count; $i++) {
+        if ($Lines[$i] -eq $Value) {
+            $indexes += $i
+        }
+    }
+
+    return @($indexes)
+}
+
+function Write-FileAtomically {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Content,
+
+        [string]$BackupPath
+    )
+
+    $directory = Split-Path -Parent $Path
+    Ensure-Directory -Path $directory
+    $temporaryPath = New-TemporaryPath -Directory $directory -Prefix "write"
+    $replaceBackupPath = $BackupPath
+
+    if ($replaceBackupPath) {
+        Ensure-Directory -Path (Split-Path -Parent $replaceBackupPath)
+    }
+
+    try {
+        [System.IO.File]::WriteAllText($temporaryPath, $Content, (Get-Utf8NoBomEncoding))
+
+        if (Test-Path $Path -PathType Leaf) {
+            if (-not $replaceBackupPath) {
+                $replaceBackupPath = New-TemporaryPath -Directory $directory -Prefix "write-backup"
+            }
+
+            [System.IO.File]::Replace($temporaryPath, $Path, $replaceBackupPath, $true)
+        } else {
+            [System.IO.File]::Move($temporaryPath, $Path)
+        }
+    } finally {
+        if (Test-Path $temporaryPath -PathType Leaf) {
+            Remove-Item $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+
+        if (-not $BackupPath -and $replaceBackupPath -and (Test-Path $replaceBackupPath -PathType Leaf)) {
+            Remove-Item $replaceBackupPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Replace-FileAtomically {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourcePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationPath,
+
+        [string]$BackupPath
+    )
+
+    if (-not (Test-Path $SourcePath -PathType Leaf)) {
+        throw "Source file not found: $SourcePath"
+    }
+
+    $directory = Split-Path -Parent $DestinationPath
+    Ensure-Directory -Path $directory
+    $temporaryPath = New-TemporaryPath -Directory $directory -Prefix "replace"
+    $replaceBackupPath = $BackupPath
+
+    if ($replaceBackupPath) {
+        Ensure-Directory -Path (Split-Path -Parent $replaceBackupPath)
+    }
+
+    try {
+        [System.IO.File]::Copy($SourcePath, $temporaryPath, $true)
+
+        if (Test-Path $DestinationPath -PathType Leaf) {
+            if (-not $replaceBackupPath) {
+                $replaceBackupPath = New-TemporaryPath -Directory $directory -Prefix "replace-backup"
+            }
+
+            [System.IO.File]::Replace($temporaryPath, $DestinationPath, $replaceBackupPath, $true)
+        } else {
+            [System.IO.File]::Move($temporaryPath, $DestinationPath)
+        }
+    } finally {
+        if (Test-Path $temporaryPath -PathType Leaf) {
+            Remove-Item $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+
+        if (-not $BackupPath -and $replaceBackupPath -and (Test-Path $replaceBackupPath -PathType Leaf)) {
+            Remove-Item $replaceBackupPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Get-IpsetPaths {
+    $listsDir = Join-Path $script:ZapretRootDir "lists"
+
+    New-Object PSObject -Property @{
+        ListsDir   = $listsDir
+        ActiveFile = Join-Path $listsDir "ipset-all.txt"
+        LoadedFile = Join-Path $listsDir "ipset-all.txt.loaded"
+        BackupFile = Join-Path $listsDir "ipset-all.txt.backup"
+        StateFile  = Join-Path $listsDir "ipset-all.state"
+    }
+}
+
+function Test-IpsetMode {
+    param(
+        [AllowNull()]
+        [string]$Mode
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Mode)) {
+        return $false
+    }
+
+    return @("loaded", "any", "none") -contains $Mode.Trim().ToLowerInvariant()
+}
+
+function Get-LegacyIpsetMode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ActiveFile
+    )
+
+    if (-not (Test-Path $ActiveFile -PathType Leaf)) {
+        return "none"
+    }
+
+    $lines = @(Get-Content -Path $ActiveFile)
+    $nonEmptyLines = @($lines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+    if ($nonEmptyLines.Count -eq 0) {
+        return "any"
+    }
+
+    if ($nonEmptyLines.Count -eq 1 -and $nonEmptyLines[0].Trim() -eq $script:DummyIpsetEntry) {
+        return "none"
+    }
+
+    return "loaded"
+}
+
+function Test-IpsetLine {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Line
+    )
+
+    $trimmed = $Line.Trim()
+    if ($trimmed.Length -eq 0 -or $trimmed.StartsWith("#") -or $trimmed.StartsWith(";")) {
+        return $true
+    }
+
+    $match = [regex]::Match($trimmed, '^(?<ip>[^/\s]+)(?:/(?<mask>\d{1,3}))?$')
+    if (-not $match.Success) {
+        return $false
+    }
+
+    $parsedIp = $null
+    if (-not [System.Net.IPAddress]::TryParse($match.Groups["ip"].Value, [ref]$parsedIp)) {
+        return $false
+    }
+
+    if ($match.Groups["mask"].Success) {
+        [int]$maskValue = $match.Groups["mask"].Value
+        $maxMask = 32
+        if ($parsedIp.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6) {
+            $maxMask = 128
+        }
+
+        if ($maskValue -lt 0 -or $maskValue -gt $maxMask) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Validate-IpsetContent {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Content
+    )
+
+    $lines = Split-NormalizedLines -Text $Content
+    $entryCount = 0
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i].Trim()
+        if ($line.Length -eq 0 -or $line.StartsWith("#") -or $line.StartsWith(";")) {
+            continue
+        }
+
+        if (-not (Test-IpsetLine -Line $line)) {
+            throw "Invalid IPSet entry at line $($i + 1): $line"
+        }
+
+        $entryCount++
+    }
+
+    if ($entryCount -eq 0) {
+        throw "Downloaded IPSet list is empty."
+    }
+}
+
+function Initialize-IpsetState {
+    $paths = Get-IpsetPaths
+    Ensure-Directory -Path $paths.ListsDir
+
+    $legacyMode = Get-LegacyIpsetMode -ActiveFile $paths.ActiveFile
+    $state = $null
+
+    if (Test-Path $paths.StateFile -PathType Leaf) {
+        $candidate = (Read-FileText -Path $paths.StateFile).Trim().ToLowerInvariant()
+        if (Test-IpsetMode -Mode $candidate) {
+            $state = $candidate
+        }
+    }
+
+    if (-not $state) {
+        $state = $legacyMode
+        if ($state -eq "none" -and (Test-Path $paths.LoadedFile -PathType Leaf)) {
+            $state = "loaded"
+        }
+
+        Write-FileAtomically -Path $paths.StateFile -Content ($state + "`r`n")
+    }
+
+    if (-not (Test-Path $paths.LoadedFile -PathType Leaf)) {
+        if ($legacyMode -eq "loaded" -and (Test-Path $paths.ActiveFile -PathType Leaf)) {
+            Replace-FileAtomically -SourcePath $paths.ActiveFile -DestinationPath $paths.LoadedFile
+        } elseif (Test-Path $paths.BackupFile -PathType Leaf) {
+            [System.IO.File]::Move($paths.BackupFile, $paths.LoadedFile)
+        }
+    }
+
+    if ($state -eq "loaded" -and -not (Test-Path $paths.LoadedFile -PathType Leaf) -and $legacyMode -ne "loaded") {
+        $state = $legacyMode
+        Write-FileAtomically -Path $paths.StateFile -Content ($state + "`r`n")
+    }
+
+    return $state
+}
+
+function Get-IpsetStatus {
+    Initialize-IpsetState
+}
+
+function Write-IpsetActiveFileForMode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Mode
+    )
+
+    $paths = Get-IpsetPaths
+
+    switch ($Mode) {
+        "loaded" {
+            if (-not (Test-Path $paths.LoadedFile -PathType Leaf)) {
+                throw "No cached IPSet list found. Update the list first."
+            }
+
+            Validate-IpsetContent -Content (Read-FileText -Path $paths.LoadedFile)
+            Replace-FileAtomically -SourcePath $paths.LoadedFile -DestinationPath $paths.ActiveFile
+        }
+        "any" {
+            Write-FileAtomically -Path $paths.ActiveFile -Content ""
+        }
+        "none" {
+            Write-FileAtomically -Path $paths.ActiveFile -Content ($script:DummyIpsetEntry + "`r`n")
+        }
+        default {
+            throw "Unsupported IPSet mode: $Mode"
+        }
+    }
+}
+
+function Set-IpsetMode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Mode
+    )
+
+    $targetMode = $Mode.Trim().ToLowerInvariant()
+    if (-not (Test-IpsetMode -Mode $targetMode)) {
+        throw "Invalid IPSet mode: $Mode"
+    }
+
+    $paths = Get-IpsetPaths
+    $currentMode = Initialize-IpsetState
+
+    if ($currentMode -eq $targetMode) {
+        return $targetMode
+    }
+
+    try {
+        Write-IpsetActiveFileForMode -Mode $targetMode
+        Write-FileAtomically -Path $paths.StateFile -Content ($targetMode + "`r`n")
+    } catch {
+        try {
+            Write-IpsetActiveFileForMode -Mode $currentMode
+        } catch {
+        }
+
+        throw
+    }
+
+    return $targetMode
+}
+
+function Get-NextIpsetMode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Mode
+    )
+
+    switch ($Mode) {
+        "loaded" { return "none" }
+        "none" { return "any" }
+        default { return "loaded" }
+    }
+}
+
+function Switch-IpsetMode {
+    $currentMode = Get-IpsetStatus
+    $nextMode = Get-NextIpsetMode -Mode $currentMode
+
+    Write-Host ("Switching IPSet mode from '{0}' to '{1}'..." -f $currentMode, $nextMode) -ForegroundColor Cyan
+    Set-IpsetMode -Mode $nextMode | Out-Null
+    Write-Host ("IPSet mode is now '{0}'." -f $nextMode) -ForegroundColor Green
+
+    return $nextMode
+}
+
+function Download-TextFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationPath
+    )
+
+    Ensure-Directory -Path (Split-Path -Parent $DestinationPath)
+
+    try {
+        $previousProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+        Invoke-WebRequest -Uri $Url -TimeoutSec 20 -UseBasicParsing -OutFile $DestinationPath
+    } catch {
+        $downloadError = $_.Exception.Message
+        $curl = Get-Command "curl.exe" -ErrorAction SilentlyContinue
+        if (-not $curl) {
+            throw "Failed to download $Url. $downloadError"
+        }
+
+        & $curl.Source -L --fail --silent --show-error -o $DestinationPath $Url
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to download $Url. PowerShell downloader: $downloadError"
+        }
+    } finally {
+        $ProgressPreference = $previousProgressPreference
+    }
+}
+
+function Update-IpsetList {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url
+    )
+
+    $paths = Get-IpsetPaths
+    $currentMode = Get-IpsetStatus
+    $stagingDirectory = Get-StagingDirectory
+    $temporaryPath = New-TemporaryPath -Directory $stagingDirectory -Prefix "ipset-download"
+    $activeRollbackPath = $null
+
+    try {
+        Write-Host "Downloading IPSet list..." -ForegroundColor Cyan
+        Download-TextFile -Url $Url -DestinationPath $temporaryPath
+
+        Write-Host "Download complete. Validating IPSet list..." -ForegroundColor DarkGray
+        $downloadedContent = Read-FileText -Path $temporaryPath
+        Validate-IpsetContent -Content $downloadedContent
+
+        if ($currentMode -eq "loaded" -and (Test-Path $paths.ActiveFile -PathType Leaf)) {
+            $activeRollbackPath = New-TemporaryPath -Directory $stagingDirectory -Prefix "ipset-active-rollback"
+            [System.IO.File]::Copy($paths.ActiveFile, $activeRollbackPath, $true)
+        }
+
+        Write-Host "Applying IPSet update..." -ForegroundColor DarkGray
+        Replace-FileAtomically -SourcePath $temporaryPath -DestinationPath $paths.LoadedFile -BackupPath $paths.BackupFile
+
+        if ($currentMode -eq "loaded") {
+            try {
+                Replace-FileAtomically -SourcePath $paths.LoadedFile -DestinationPath $paths.ActiveFile
+            } catch {
+                if (Test-Path $paths.BackupFile -PathType Leaf) {
+                    Replace-FileAtomically -SourcePath $paths.BackupFile -DestinationPath $paths.LoadedFile
+                } elseif ($activeRollbackPath -and (Test-Path $activeRollbackPath -PathType Leaf)) {
+                    Replace-FileAtomically -SourcePath $activeRollbackPath -DestinationPath $paths.LoadedFile
+                }
+
+                if ($activeRollbackPath -and (Test-Path $activeRollbackPath -PathType Leaf)) {
+                    Replace-FileAtomically -SourcePath $activeRollbackPath -DestinationPath $paths.ActiveFile
+                }
+
+                throw
+            }
+        }
+
+        Write-Host "IPSet list updated successfully." -ForegroundColor Green
+        if ($currentMode -ne "loaded") {
+            Write-Host ("Cached list updated; active mode remains '{0}'." -f $currentMode) -ForegroundColor DarkGray
+        }
+    } finally {
+        if (Test-Path $temporaryPath -PathType Leaf) {
+            Remove-Item $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+
+        if ($activeRollbackPath -and (Test-Path $activeRollbackPath -PathType Leaf)) {
+            Remove-Item $activeRollbackPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Get-ManagedHostsPayloadLines {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Text
+    )
+
+    $lines = @(Split-NormalizedLines -Text $Text)
+    if ($lines.Count -gt 0) {
+        $lines[0] = $lines[0].TrimStart([char]0xFEFF)
+    }
+
+    $beginIndexes = @(Get-ExactLineIndexes -Lines $lines -Value $script:ManagedHostsBegin)
+    $endIndexes = @(Get-ExactLineIndexes -Lines $lines -Value $script:ManagedHostsEnd)
+
+    if (($beginIndexes.Count + $endIndexes.Count) -gt 0) {
+        if ($beginIndexes.Count -ne 1 -or $endIndexes.Count -ne 1 -or $beginIndexes[0] -ge $endIndexes[0]) {
+            throw "Downloaded hosts content contains invalid managed block markers."
+        }
+
+        if (($endIndexes[0] - $beginIndexes[0]) -gt 1) {
+            $lines = @($lines[($beginIndexes[0] + 1)..($endIndexes[0] - 1)])
+        } else {
+            $lines = @()
+        }
+    }
+
+    $lines = @(Trim-BlankEdgeLines -Lines $lines)
+    if ($lines.Count -eq 0) {
+        throw "Downloaded hosts block is empty."
+    }
+
+    return @($lines)
+}
+
+function Merge-ManagedHostsBlock {
+    param(
+        [AllowNull()]
+        [string]$CurrentText,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string[]]$ManagedPayloadLines
+    )
+
+    $lines = @(Split-NormalizedLines -Text $CurrentText)
+    if ($lines.Count -gt 0) {
+        $lines[0] = $lines[0].TrimStart([char]0xFEFF)
+    }
+
+    $beginIndexes = @(Get-ExactLineIndexes -Lines $lines -Value $script:ManagedHostsBegin)
+    $endIndexes = @(Get-ExactLineIndexes -Lines $lines -Value $script:ManagedHostsEnd)
+
+    if ($beginIndexes.Count -ne $endIndexes.Count) {
+        throw "Hosts file contains an incomplete managed block."
+    }
+
+    if ($beginIndexes.Count -gt 1) {
+        throw "Hosts file contains multiple managed blocks."
+    }
+
+    $managedBlock = @($script:ManagedHostsBegin) + $ManagedPayloadLines + @($script:ManagedHostsEnd)
+
+    if ($beginIndexes.Count -eq 1) {
+        if ($beginIndexes[0] -ge $endIndexes[0]) {
+            throw "Hosts file contains a malformed managed block."
+        }
+
+        $before = @()
+        $after = @()
+
+        if ($beginIndexes[0] -gt 0) {
+            $before = @($lines[0..($beginIndexes[0] - 1)])
+        }
+
+        if (($endIndexes[0] + 1) -lt $lines.Count) {
+            $after = @($lines[($endIndexes[0] + 1)..($lines.Count - 1)])
+        }
+
+        $mergedLines = @($before + $managedBlock + $after)
+    } else {
+        $mergedLines = @($lines)
+
+        while ($mergedLines.Count -gt 0 -and [string]::IsNullOrWhiteSpace($mergedLines[$mergedLines.Count - 1])) {
+            if ($mergedLines.Count -eq 1) {
+                $mergedLines = @()
+            } else {
+                $mergedLines = @($mergedLines[0..($mergedLines.Count - 2)])
+            }
+        }
+
+        if ($mergedLines.Count -gt 0) {
+            $mergedLines += ""
+        }
+
+        $mergedLines += $managedBlock
+    }
+
+    return (($mergedLines -join "`r`n") + "`r`n")
+}
+
+function Update-HostsFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url,
+
+        [string]$HostsFilePath = (Join-Path $env:SystemRoot "System32\drivers\etc\hosts")
+    )
+
+    $hostsDirectory = Split-Path -Parent $HostsFilePath
+    $stagingDirectory = Get-StagingDirectory
+    $temporaryPath = New-TemporaryPath -Directory $stagingDirectory -Prefix "hosts-download"
+    $backupPath = Join-Path $hostsDirectory "hosts.zapret-discord-youtube.backup"
+
+    try {
+        Write-Host "Downloading hosts block..." -ForegroundColor Cyan
+        Download-TextFile -Url $Url -DestinationPath $temporaryPath
+
+        Write-Host "Download complete. Preparing hosts merge..." -ForegroundColor DarkGray
+        $payloadLines = Get-ManagedHostsPayloadLines -Text (Read-FileText -Path $temporaryPath)
+        $currentText = Read-FileText -Path $HostsFilePath
+        $mergedText = Merge-ManagedHostsBlock -CurrentText $currentText -ManagedPayloadLines $payloadLines
+
+        if ((Normalize-ComparableText -Text $currentText) -eq (Normalize-ComparableText -Text $mergedText)) {
+            Write-Host "Hosts file is up to date." -ForegroundColor Green
+            return $false
+        }
+
+        Write-Host "Applying hosts update..." -ForegroundColor DarkGray
+        Write-FileAtomically -Path $HostsFilePath -Content $mergedText -BackupPath $backupPath
+        Write-Host "Hosts file updated successfully." -ForegroundColor Green
+        Write-Host "Backup saved to $backupPath" -ForegroundColor DarkGray
+
+        return $true
+    } finally {
+        if (Test-Path $temporaryPath -PathType Leaf) {
+            Remove-Item $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+if ($CommandName) {
+    try {
+        switch ($CommandName.Trim().ToLowerInvariant()) {
+            "get-ipset-status" {
+                Write-Output (Get-IpsetStatus)
+            }
+            "switch-ipset" {
+                Switch-IpsetMode | Out-Null
+            }
+            "set-ipset-mode" {
+                if (-not $Argument1) {
+                    throw "IPSet mode is required."
+                }
+
+                Set-IpsetMode -Mode $Argument1 | Out-Null
+            }
+            "update-ipset" {
+                if (-not $Argument1) {
+                    throw "IPSet URL is required."
+                }
+
+                Update-IpsetList -Url $Argument1
+            }
+            "update-hosts" {
+                if (-not $Argument1) {
+                    throw "Hosts URL is required."
+                }
+
+                if ($Argument2) {
+                    Update-HostsFile -Url $Argument1 -HostsFilePath $Argument2 | Out-Null
+                } else {
+                    Update-HostsFile -Url $Argument1 | Out-Null
+                }
+            }
+            default {
+                throw "Unknown command: $CommandName"
+            }
+        }
+    } catch {
+        Write-Host ("[ERROR] {0}" -f $_.Exception.Message) -ForegroundColor Red
+        exit 1
+    }
+}

--- a/utils/test zapret.ps1
+++ b/utils/test zapret.ps1
@@ -6,41 +6,12 @@ $utilsDir = Join-Path $rootDir "utils"
 $resultsDir = Join-Path $utilsDir "test results"
 if (-not (Test-Path $resultsDir)) { New-Item -ItemType Directory -Path $resultsDir | Out-Null }
 
-# Define functions early
-function Get-IpsetStatus {
-    $listFile = Join-Path $listsDir "ipset-all.txt"
-    if (-not (Test-Path $listFile)) { return "none" }
-    $lineCount = (Get-Content $listFile | Measure-Object -Line).Lines
-    if ($lineCount -eq 0) { return "any" }
-    $hasDummy = Get-Content $listFile | Select-String -Pattern "203\.0\.113\.113/32" -Quiet
-    if ($hasDummy) { return "none" } else { return "loaded" }
-}
-
-function Set-IpsetMode {
-    param([string]$mode)
-    $listFile = Join-Path $listsDir "ipset-all.txt"
-    $backupFile = Join-Path $listsDir "ipset-all.test-backup.txt"
-    if ($mode -eq "any") {
-        # Always backup current file (even if none)
-        if (Test-Path $listFile) {
-            Copy-Item $listFile $backupFile -Force
-        } else {
-            # If none, create empty backup
-            "" | Out-File $backupFile -Encoding UTF8
-        }
-        # Make file empty
-        "" | Out-File $listFile -Encoding UTF8
-    } elseif ($mode -eq "restore") {
-        if (Test-Path $backupFile) {
-            Move-Item $backupFile $listFile -Force
-        }
-    }
-}
+. (Join-Path $utilsDir "service-state.ps1")
 
 trap {
     Write-Host "[ERROR] Script interrupted. Restoring ipset..." -ForegroundColor Red
     if ($originalIpsetStatus -and $originalIpsetStatus -ne "any") {
-        Set-IpsetMode -mode "restore"
+        Set-IpsetMode -Mode $originalIpsetStatus | Out-Null
     }
     Remove-Item -Path $ipsetFlagFile -ErrorAction SilentlyContinue
     break
@@ -336,8 +307,18 @@ if (-not (Get-Command "curl.exe" -ErrorAction SilentlyContinue)) {
 # Check for leftover ipset flag from previous interrupted run
 $ipsetFlagFile = Join-Path $rootDir "ipset_switched.flag"
 if (Test-Path $ipsetFlagFile) {
-    Write-Host "[INFO] Detected leftover ipset switch flag. Restoring ipset..." -ForegroundColor Yellow
-    Set-IpsetMode -mode "restore"
+    $storedIpsetMode = ((Get-Content $ipsetFlagFile -ErrorAction SilentlyContinue | Select-Object -First 1) -as [string])
+    if ($storedIpsetMode) {
+        $storedIpsetMode = $storedIpsetMode.Trim().ToLowerInvariant()
+    }
+
+    if (Test-IpsetMode -Mode $storedIpsetMode) {
+        Write-Host "[INFO] Detected leftover ipset switch flag. Restoring ipset..." -ForegroundColor Yellow
+        Set-IpsetMode -Mode $storedIpsetMode | Out-Null
+    } else {
+        Write-Host "[WARNING] Detected leftover ipset switch flag without a valid mode. Skipping restore." -ForegroundColor Yellow
+    }
+
     Remove-Item -Path $ipsetFlagFile -ErrorAction SilentlyContinue
 }
 
@@ -607,9 +588,9 @@ try {
     # Save original ipset status and switch to 'any' for accurate DPI tests
     if (($originalIpsetStatus -ne "any") -and ($testType -eq 'dpi')) {
         Write-Host "[WARNING] Ipset is in '$originalIpsetStatus' mode. Switching to 'any' for accurate DPI tests..." -ForegroundColor Yellow
-        Set-IpsetMode -mode "any"
+        Set-IpsetMode -Mode "any" | Out-Null
         # Create flag file to indicate ipset was switched
-        "" | Out-File -FilePath $ipsetFlagFile -Encoding UTF8
+        [System.IO.File]::WriteAllText($ipsetFlagFile, ($originalIpsetStatus + "`r`n"), (Get-Utf8NoBomEncoding))
     }
     Write-Host "[WARNING] Tests may take several minutes to complete. Please wait..." -ForegroundColor Yellow
 
@@ -925,7 +906,7 @@ try {
 } catch {
     Write-Host "[ERROR] An error occurred during tests. Restoring ipset..." -ForegroundColor Red
     if ($originalIpsetStatus -and $originalIpsetStatus -ne "any") {
-        Set-IpsetMode -mode "restore"
+        Set-IpsetMode -Mode $originalIpsetStatus | Out-Null
     }
     Remove-Item -Path $ipsetFlagFile -ErrorAction SilentlyContinue
 } finally {
@@ -933,7 +914,7 @@ try {
     Restore-WinwsSnapshot -snapshot $originalWinws
     if ($originalIpsetStatus -ne "any") {
         Write-Host "[INFO] Restoring original ipset mode..." -ForegroundColor DarkGray
-        Set-IpsetMode -mode "restore"
+        Set-IpsetMode -Mode $originalIpsetStatus | Out-Null
     }
     Remove-Item -Path $ipsetFlagFile -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
# Сделать обновления IPSet и hosts атомарными и безопасными к откату

---

## Что изменено

- обновление **IPSet** переведено на:
  - временный файл
  - валидацию
  - бэкап
  - атомарную замену

- режим **IPSet** вынесен в отдельный **state-файл**  
  вместо кодирования через содержимое `ipset-all.txt`

- загруженный список **IPSet** хранится отдельно от активного файла

- `hosts` обновляется через управляемый блок: