### PR TITLE
Update general list

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -45,3 +45,4 @@ betterttv.net
 7tv.app
 7tv.io
 localizeapi.com
+klipy.com


### PR DESCRIPTION
Добавлен домен нового встроенного GIF сервиса Klipy в Discord.

Достаточно static.klipy.com но пусть ещё и сайт работает.