### PR TITLE
Fix Warface voice chat by adding required domains to list-exclude.txt

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -41,3 +41,8 @@ riotcdn.net
 leagueoflegends.com
 playvalorant.com
 marketplace.visualstudio.com
+tcloud.tim.qq.com
+gmeconf.qcloud.com
+yun.tim.qq.com
+gmeosconf.qcloud.com
+sg.global.gme.qcloud.com


### PR DESCRIPTION
## Проблема
Голосовой чат в игре Warface не работает при использовании zapret (обнаружено на ALT 11).

## Решение
Добавлены домены голосового чата Warface в файл исключений `list-exclude.txt`.

## Добавленные домены
tcloud.tim.qq.com
gmeconf.qcloud.com
yun.tim.qq.com
gmeosconf.qcloud.com
sg.global.gme.qcloud.com

## Проверка
- [x] Голосовой чат в Warface работает корректно
- [x] Остальные функции zapret не пострадали