### PR TITLE
fix status ipfilter bug

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,19 @@
+name: Validate Repository
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate launchers and service helpers
+        shell: powershell
+        run: .\utils\validate-repo.ps1

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,15 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.zapret-discord-youtube.iml
+/modules.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/service.bat
+++ b/service.bat
@@ -27,6 +27,13 @@ if "%~1"=="load_game_filter" (
     exit /b
 )
 
+if "%~1"=="status_ipset" (
+    setlocal EnableDelayedExpansion
+    call :ipset_switch_status
+    echo !IPsetStatus!
+    exit /b 0
+)
+
 if "%~1"=="load_user_lists" (
     call :load_user_lists
     exit /b
@@ -811,19 +818,22 @@ goto menu
 chcp 437 > nul
 
 set "listFile=%~dp0lists\ipset-all.txt"
-for /f %%i in ('type "%listFile%" 2^>nul ^| find /c /v ""') do set "lineCount=%%i"
+set "IPsetStatus=none"
 
-if !lineCount!==0 (
-    set "IPsetStatus=any"
-) else (
-    findstr /R "^203\.0\.113\.113/32$" "%listFile%" >nul
-    if !errorlevel!==0 (
-        set "IPsetStatus=none"
-    ) else (
-        set "IPsetStatus=loaded"
-    )
+if not exist "%listFile%" (
+    exit /b 0
 )
-exit /b
+
+for %%A in ("%listFile%") do if %%~zA EQU 0 (
+    set "IPsetStatus=any"
+    exit /b 0
+)
+
+findstr /X /C:"203.0.113.113/32" "%listFile%" >nul
+if errorlevel 1 (
+    set "IPsetStatus=loaded"
+)
+exit /b 0
 
 
 :ipset_switch

--- a/utils/validate-repo.ps1
+++ b/utils/validate-repo.ps1
@@ -1,0 +1,193 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+$rootDir = Split-Path $PSScriptRoot
+$serviceBat = Join-Path $rootDir "service.bat"
+$listsDir = Join-Path $rootDir "lists"
+$ipsetFile = Join-Path $listsDir "ipset-all.txt"
+$generatedListFiles = @(
+    "ipset-exclude-user.txt",
+    "list-exclude-user.txt",
+    "list-general-user.txt"
+)
+$requiredBootstrapCalls = @(
+    "call service.bat status_zapret",
+    "call service.bat check_updates",
+    "call service.bat load_game_filter",
+    "call service.bat load_user_lists"
+)
+$errors = New-Object System.Collections.Generic.List[string]
+
+function Add-ValidationError {
+    param([string]$Message)
+
+    $script:errors.Add($Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+function Write-ValidationInfo {
+    param([string]$Message)
+
+    Write-Host "[INFO] $Message" -ForegroundColor DarkCyan
+}
+
+function Assert-FileExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Add-ValidationError "$Label missing: $Path"
+    }
+}
+
+function Get-ServiceIpsetStatus {
+    $stdoutFile = Join-Path $env:TEMP ("zapret-validate-" + [System.Guid]::NewGuid().ToString("N") + ".out")
+    $stderrFile = Join-Path $env:TEMP ("zapret-validate-" + [System.Guid]::NewGuid().ToString("N") + ".err")
+
+    try {
+        $process = Start-Process -FilePath "cmd.exe" `
+            -ArgumentList "/d", "/c", ('call "' + $serviceBat + '" status_ipset') `
+            -NoNewWindow `
+            -Wait `
+            -PassThru `
+            -RedirectStandardOutput $stdoutFile `
+            -RedirectStandardError $stderrFile
+
+        $output = ""
+        if (Test-Path -LiteralPath $stdoutFile) {
+            $output = (Get-Content -LiteralPath $stdoutFile -Raw).Trim()
+        }
+
+        if ($process.ExitCode -ne 0) {
+            $stderr = ""
+            if (Test-Path -LiteralPath $stderrFile) {
+                $stderr = (Get-Content -LiteralPath $stderrFile -Raw).Trim()
+            }
+
+            throw "service.bat status_ipset failed with exit code $($process.ExitCode). $stderr"
+        }
+
+        return $output
+    }
+    finally {
+        Remove-Item -LiteralPath $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-ValidationInfo "Checking root batch layout..."
+$rootBatchFiles = Get-ChildItem -LiteralPath $rootDir -Filter "*.bat" -File | Sort-Object Name
+$strategyFiles = $rootBatchFiles | Where-Object { $_.Name -notlike "service*" }
+
+if (-not $strategyFiles) {
+    Add-ValidationError "No strategy batch files were found in the repository root."
+}
+
+$unexpectedRootBatchFiles = $strategyFiles | Where-Object { $_.Name -notlike "general*.bat" }
+foreach ($file in $unexpectedRootBatchFiles) {
+    Add-ValidationError "Unexpected root batch file '$($file.Name)'. service.bat offers every non-service root .bat as an installable service."
+}
+
+Write-ValidationInfo "Checking launcher bootstrap and referenced files..."
+$serviceContent = Get-Content -LiteralPath $serviceBat -Raw
+foreach ($generatedListFile in $generatedListFiles) {
+    if ($serviceContent -notmatch [regex]::Escape($generatedListFile)) {
+        Add-ValidationError "service.bat no longer provisions generated user list '$generatedListFile'."
+    }
+}
+
+foreach ($strategyFile in $strategyFiles) {
+    $content = Get-Content -LiteralPath $strategyFile.FullName -Raw
+
+    foreach ($call in $requiredBootstrapCalls) {
+        if ($content -notmatch [regex]::Escape($call)) {
+            Add-ValidationError "$($strategyFile.Name) is missing bootstrap call '$call'."
+        }
+    }
+
+    if ($content -notmatch '%BIN%winws\.exe') {
+        Add-ValidationError "$($strategyFile.Name) does not launch %BIN%winws.exe."
+    }
+
+    $binRefs = [regex]::Matches($content, '%BIN%([^"\s\r\n]+)') |
+        ForEach-Object { $_.Groups[1].Value } |
+        Sort-Object -Unique
+    foreach ($relativePath in $binRefs) {
+        $fullPath = Join-Path (Join-Path $rootDir "bin") $relativePath
+        Assert-FileExists -Path $fullPath -Label "$($strategyFile.Name) references missing bin asset '$relativePath'"
+    }
+
+    $listRefs = [regex]::Matches($content, '%LISTS%([^"\s\r\n]+)') |
+        ForEach-Object { $_.Groups[1].Value } |
+        Sort-Object -Unique
+    foreach ($relativePath in $listRefs) {
+        if ($generatedListFiles -contains $relativePath) {
+            continue
+        }
+
+        $fullPath = Join-Path $listsDir $relativePath
+        Assert-FileExists -Path $fullPath -Label "$($strategyFile.Name) references missing list '$relativePath'"
+    }
+}
+
+Write-ValidationInfo "Checking IPSet status detection through service.bat..."
+$originalIpsetExists = Test-Path -LiteralPath $ipsetFile -PathType Leaf
+$originalIpsetBytes = $null
+if ($originalIpsetExists) {
+    $originalIpsetBytes = [System.IO.File]::ReadAllBytes($ipsetFile)
+}
+
+try {
+    $cases = @(
+        @{
+            Name = "loaded"
+            Expected = "loaded"
+            Bytes = [System.Text.Encoding]::ASCII.GetBytes("1.1.1.1/32`r`n")
+        },
+        @{
+            Name = "none"
+            Expected = "none"
+            Bytes = [System.Text.Encoding]::ASCII.GetBytes("203.0.113.113/32`r`n")
+        },
+        @{
+            Name = "any"
+            Expected = "any"
+            Bytes = [byte[]]@()
+        },
+        @{
+            Name = "missing"
+            Expected = "none"
+            Remove = $true
+        }
+    )
+
+    foreach ($case in $cases) {
+        if ($case.ContainsKey("Remove") -and $case["Remove"]) {
+            Remove-Item -LiteralPath $ipsetFile -Force -ErrorAction SilentlyContinue
+        } else {
+            [System.IO.File]::WriteAllBytes($ipsetFile, $case.Bytes)
+        }
+
+        $actual = Get-ServiceIpsetStatus
+        if ($actual -ne $case.Expected) {
+            Add-ValidationError "service.bat status_ipset returned '$actual' for $($case.Name) mode; expected '$($case.Expected)'."
+        }
+    }
+}
+finally {
+    if ($originalIpsetExists) {
+        [System.IO.File]::WriteAllBytes($ipsetFile, $originalIpsetBytes)
+    } else {
+        Remove-Item -LiteralPath $ipsetFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($errors.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Validation failed with $($errors.Count) error(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Validation completed successfully." -ForegroundColor Green


### PR DESCRIPTION
  В service.bat статус режима IPSet Filter мог определяться неверно, из-за чего меню показывало неправильное состояние loaded, none или any, а переключение режимов становилось непредсказуемым для пользователя.
  - исправлена логика :ipset_switch_status в service.bat
      - если ipset-all.txt отсутствует, статус определяется как none
      - если ipset-all.txt пустой, статус определяется как any
      - если файл содержит только служебную заглушку 203.0.113.113/32, статус определяется как none
      - во всех остальных непустых случаях статус определяется как loaded
  - упрощена и стабилизирована логика определения статуса за счёт точного сравнения с placeholder-значением
  - добавлен скрытый режим status_ipset для неинтерактивной проверки статуса из автоматических скриптов
  - добавлен utils/validate-repo.ps1, который проверяет:
      - структуру .bat-файлов в корне репозитория
      - наличие обязательных bootstrap-вызовов в general*.bat
      - существование файлов, на которые ссылаются launchers в bin/ и lists/
      - корректность обработки auto-generated user lists
      - реальные переходы состояний IPSet через сам service.bat

