### PR TITLE
Fix missing quotes around %GameFilterChoice% in if statement

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -751,7 +751,7 @@ echo   3. UDP only
 echo.
 set "GameFilterChoice=0"
 set /p "GameFilterChoice=Select option (0-3, default: 0): "
-if %GameFilterChoice%=="" set "GameFilterChoice=0"
+if "%GameFilterChoice%"=="" set "GameFilterChoice=0"
 
 if "%GameFilterChoice%"=="0" (
     if exist "%gameFlagFile%" (


### PR DESCRIPTION
`service.bat:754`

```bat
if %GameFilterChoice%=="" set "GameFilterChoice=0"
```

If the variable were ever empty, cmd would throw a syntax error
because `==""` has no left operand. Currently unreachable since
the default is set right above (`set "GameFilterChoice=0"`), but
the line is still syntactically wrong.

Fixed:
```bat
if "%GameFilterChoice%"=="" set "GameFilterChoice=0"
```

Partially addresses #12133 (missing quotes issue).