### PR TITLE
Add curl --ssl-revoke-best-effort

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -883,7 +883,12 @@ set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/
 echo Updating ipset-all...
 
 if exist "%SystemRoot%\System32\curl.exe" (
-    curl --ssl-revoke-best-effort -L -o "%listFile%" "%url%"
+    curl --version | find "libcurl/7"
+    if !errorlevel!==0 (
+        curl --ssl-no-revoke -L -o "%listFile%" "%url%"
+    ) else (
+        curl --ssl-revoke-best-effort -L -o "%listFile%" "%url%"
+    )
 ) else (
     powershell -NoProfile -Command ^
         "$url = '%url%';" ^

--- a/service.bat
+++ b/service.bat
@@ -883,7 +883,7 @@ set "url=https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/
 echo Updating ipset-all...
 
 if exist "%SystemRoot%\System32\curl.exe" (
-    curl -L -o "%listFile%" "%url%"
+    curl --ssl-revoke-best-effort -L -o "%listFile%" "%url%"
 ) else (
     powershell -NoProfile -Command ^
         "$url = '%url%';" ^


### PR DESCRIPTION
Участились случаи "schannel: next InitializeSecurityContext failed: CRYPT_E_REVOCATION_OFFLINE":
https://github.com/Flowseal/zapret-discord-youtube/issues/11824
https://github.com/Flowseal/zapret-discord-youtube/issues/12402

Добавил ключ `--ssl-revoke-best-effort` при обновлении ipset.txt
Для файла hosts добавлять не стал, считаю файл hosts более критическим для ОС. Пусть там полностью проверяет сертификат. 