### PR TITLE
Добавление стратегии general (ALT12): фикс голоса Discord с расширенным диапазоном UDP

### DIFF
--- a/general (ALT12).bat
+++ b/general (ALT12).bat
@@ -1,0 +1,24 @@
+@echo off
+chcp 65001 > nul
+:: 65001 - UTF-8
+:: Discord voice fix: expanded UDP range 50000-65535, removed filter-l7, added any-protocol
+
+cd /d "%~dp0"
+call service.bat status_zapret
+call service.bat check_updates
+call service.bat load_game_filter
+echo:
+
+set "BIN=%~dp0bin\"
+set "LISTS=%~dp0lists\"
+cd /d %BIN%
+
+start "zapret: %~n0" /min "%BIN%winws.exe" --wf-tcp=80,443,2053,2083,2087,2096,8443,%GameFilter% --wf-udp=443,19294-19344,50000-65535,%GameFilter% ^
+--filter-udp=443 --hostlist="%LISTS%list-general.txt" --hostlist-exclude="%LISTS%list-exclude.txt" --ipset-exclude="%LISTS%ipset-exclude.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fake-quic="%BIN%quic_initial_www_google_com.bin" --new ^
+--filter-udp=19294-19344,50000-65535 --dpi-desync=fake --dpi-desync-repeats=8 --dpi-desync-any-protocol=1 --dpi-desync-fake-unknown-udp="%BIN%quic_initial_www_google_com.bin" --new ^
+--filter-tcp=2053,2083,2087,2096,8443 --hostlist-domains=discord.media --dpi-desync=fake,fakedsplit --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fakedsplit-pattern=0x00 --dpi-desync-fake-tls="%BIN%tls_clienthello_www_google_com.bin" --new ^
+--filter-tcp=443 --hostlist="%LISTS%list-google.txt" --ip-id=zero --dpi-desync=fake,fakedsplit --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fakedsplit-pattern=0x00 --dpi-desync-fake-tls="%BIN%tls_clienthello_www_google_com.bin" --new ^
+--filter-tcp=80,443 --hostlist="%LISTS%list-general.txt" --hostlist-exclude="%LISTS%list-exclude.txt" --ipset-exclude="%LISTS%ipset-exclude.txt" --dpi-desync=fake,fakedsplit --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fakedsplit-pattern=0x00 --dpi-desync-fake-tls="%BIN%tls_clienthello_www_google_com.bin" --new ^
+--filter-udp=443 --ipset="%LISTS%ipset-all.txt" --hostlist-exclude="%LISTS%list-exclude.txt" --ipset-exclude="%LISTS%ipset-exclude.txt" --dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-fake-quic="%BIN%quic_initial_www_google_com.bin" --new ^
+--filter-tcp=80,443,%GameFilter% --ipset="%LISTS%ipset-all.txt" --hostlist-exclude="%LISTS%list-exclude.txt" --ipset-exclude="%LISTS%ipset-exclude.txt" --dpi-desync=fake,fakedsplit --dpi-desync-repeats=6 --dpi-desync-fooling=ts --dpi-desync-fakedsplit-pattern=0x00 --dpi-desync-fake-tls="%BIN%tls_clienthello_www_google_com.bin" --new ^
+--filter-udp=%GameFilter% --ipset="%LISTS%ipset-all.txt" --ipset-exclude="%LISTS%ipset-exclude.txt" --dpi-desync=fake --dpi-desync-autottl=2 --dpi-desync-repeats=12 --dpi-desync-any-protocol=1 --dpi-desync-fake-unknown-udp="%BIN%quic_initial_www_google_com.bin" --dpi-desync-cutoff=n3


### PR DESCRIPTION
## Новая стратегия: general (ALT12)

Альтернативная стратегия для исправления проблем с голосовой/видеосвязью в Discord за счёт расширения диапазона UDP-портов и отказа от зависимости от `filter-l7`.

### Ключевые отличия от ALT11:
- **Расширенный диапазон UDP**: `50000-65535` вместо `50000-50100` — покрывает весь диапазон голосовых/RTP-портов Discord
- **Убран `--filter-l7=discord,stun`**: фильтрация только по портам, без анализа L7
- **Добавлен `--dpi-desync-any-protocol=1`** для UDP-фильтра Discord — более широкое покрытие десинхронизации
- **`fakedsplit`** вместо `multisplit` для TCP-десинхронизации
- **Увеличено количество повторов** до 8 для UDP-фильтра Discord

### Для кого:
Пользователи, у которых стандартные ALT-стратегии не помогают при отвалах голоса/видео в Discord — особенно когда Discord использует динамические UDP-порты выше `50100`.