### PR TITLE
Добавить gstatic.com в список list-google

### DIFF
--- a/lists/list-google.txt
+++ b/lists/list-google.txt
@@ -2,6 +2,7 @@ yt3.ggpht.com
 yt4.ggpht.com
 yt3.googleusercontent.com
 googlevideo.com
+gstatic.com
 jnn-pa.googleapis.com
 stable.dl2.discordapp.net
 wide-youtube.l.google.com


### PR DESCRIPTION
Зашёл на translate.google.com и окончательная загрузка сайта явно тормозила, не работали скрипты. Сетевой мониторинг показал, что тормозила загрузка с gstatic.com. Добавление хостинга в список решило проблему. Вероятно, это распространяется и на другие сервисы Google.