### PR TITLE
Отображение текущей стратегии в главном меню service.bat

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -58,11 +58,13 @@ cls
 call :ipset_switch_status
 call :game_switch_status
 call :check_updates_switch_status
+call :get_strategy_name
 
 set "menu_choice=null"
 
 echo.
 echo   ZAPRET SERVICE MANAGER v!LOCAL_VERSION!
+echo   Strategy: !CurrentStrategy!
 echo   ----------------------------------------
 echo.
 echo   :: SERVICE
@@ -993,6 +995,13 @@ echo.
 start "" powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0utils\test zapret.ps1"
 pause
 goto menu
+
+
+:: Get strategy name
+:get_strategy_name
+set "CurrentStrategy=not installed"
+for /f "tokens=2*" %%A in ('reg query "HKLM\System\CurrentControlSet\Services\zapret" /v zapret-discord-youtube 2^>nul') do set "CurrentStrategy=%%B"
+exit /b
 
 
 :: Utility functions


### PR DESCRIPTION
Добавил вывод названия текущей стратегии в шапку меню, чтобы сразу было видно что стоит, без необходимости лезть в Check Status.
<img width="263" height="62" alt="image" src="https://github.com/user-attachments/assets/6133f2a5-70e5-4100-aa97-ba3116953308" />

Если сервис не установлен - показывает `not installed`.
<img width="261" height="59" alt="image" src="https://github.com/user-attachments/assets/20658c1e-2635-4dad-9968-aec8f3e01ff2" />

Название берётся из того же ключа реестра, куда оно уже пишется при установке сервиса.