### PR TITLE
Исправление скачивания обновлений с GitHub

### DIFF
--- a/.service/hosts
+++ b/.service/hosts
@@ -21,6 +21,10 @@
 149.154.167.220 zws2.web.telegram.org
 149.154.167.220 zws4-1.web.telegram.org
 
+185.199.109.133 raw.githubusercontent.com
+185.199.109.133 release-assets.githubusercontent.com
+185.199.108.133 private-user-images.githubusercontent.com
+
 104.25.158.178 finland10000.discord.media
 104.25.158.178 finland10001.discord.media
 104.25.158.178 finland10002.discord.media


### PR DESCRIPTION
Со вчерашнего дня, 2 из 4 IP Fastly находятся под очень жёсткими фильтрами (110 и 111), не в фулл блоке, гитхаб как раз сидит на них. Это исправляет скачивание будущих обновлений.
https://github.com/Flowseal/zapret-discord-youtube/issues/13050#issuecomment-4385439957