### PR TITLE
Исправлен вывод результатов DPI-тестов

### DIFF
--- a/utils/test zapret.ps1
+++ b/utils/test zapret.ps1
@@ -894,13 +894,20 @@ try {
             foreach ($targetRes in $results) {
                 $id = $targetRes.TargetId
                 $provider = $targetRes.Provider
-                Add-Content $resultFile "  Target: $id ($provider)"
+                $country = $targetRes.Country
+                if ($country) {
+                    Add-Content $resultFile "  Target: [$country] $id ($provider)"
+                } else {
+                    Add-Content $resultFile "  Target: $id ($provider)"
+                }
                 foreach ($line in $targetRes.Lines) {
                     $test = $line.TestLabel
                     $code = $line.Code
-                    $size = $line.SizeKB
+                    $up = $line.UpKB
+                    $down = $line.DownKB
+                    $time = $line.Time
                     $status = $line.Status
-                    Add-Content $resultFile "    ${test}: code=${code} size=${size} KB status=${status}"
+                    Add-Content $resultFile "    ${test}: code=${code}  up=${up} KB  down=${down} KB  time=${time}s  status=${status}"
                 }
             }
         }


### PR DESCRIPTION
В файле с результатами DPI-тестов в каждой строке писалось `size= KB` без значения. Обращение шло к несуществующему свойству `$line.SizeKB`.

Заменил `SizeKB` на  `UpKB` и `DownKB` + добавил время запроса. Также в заголовок цели добавлен вывод страны. Данные уже собирались, но в файл не выводились.

Было: `HTTP: code=405 size= KB status=OK`
<img width="300" height="153" alt="image" src="https://github.com/user-attachments/assets/b3ed698a-a8d2-4365-84ca-bbc34bddad75" />

Стало: `HTTP: code=405 up=64 KB down=0.1 KB time=0.620452s status=OK`
<img width="488" height="154" alt="image" src="https://github.com/user-attachments/assets/52395e4d-8434-4155-81a6-6dcbd7a50c78" />
