### PR TITLE
Добавить 2 поддомена vsassets.io в list-exclude

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -38,6 +38,8 @@ riotcdn.net
 leagueoflegends.com
 playvalorant.com
 marketplace.visualstudio.com
+gallery.vsassets.io
+gallerycdn.vsassets.io
 gosuslugi.ru
 gov.ru
 nalog.ru


### PR DESCRIPTION
Снова появилась та же проблема с загрузкой и обновлением расширений/тем в VS Code. На данный момент проявлялась проблема как минимум у моего друга, еще [одного человека](https://github.com/Flowseal/zapret-discord-youtube/issues/13308) и у меня.

Не смогу сказать сколько она уже продолжается снова, но если я уберу поддомены из списка исключений, то начинается эта вечеринка

<img width="462" height="350" alt="image" src="https://github.com/user-attachments/assets/22a0cc95-f249-4842-b07d-8db6f9ce5042" />