### PR TITLE
chore(lists): add google.ru to Google domains list

### DIFF
--- a/lists/list-google.txt
+++ b/lists/list-google.txt
@@ -16,3 +16,4 @@ yt-video-upload.l.google.com
 ytimg.com
 ytimg.l.google.com
 play.google.com
+google.ru


### PR DESCRIPTION
### Описание изменений
Добавлен домен `google.ru` в файл списков `lists/list-google.txt`.

### Какую проблему это решает?
При попытке авторизоваться в учетной записи Google на мобильных устройствах (в частности, в браузерах Safari и Chrome на iOS/Android), сервисы Google часто выполняют автоматический редирект на локальный домен `accounts.google.ru` для верификации сессии. 

Так как доменной зоны `.ru` не было в исходном списке `list-google.txt`, трафик шел в обход стратегий десинхронизации пакетов `zapret`. В результате провайдеры блокировали/ломали HTTPS-handshake, из-за чего пользователи получали ошибку *"Браузеру не удается установить безопасное соединение с сервером"* и не могли войти в аккаунт. Добавление домена полностью решает проблему зацикливания и сбоя авторизации.

<details>
	<summary>Скриншот</summary>
 	<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/f7273e4e-a038-429c-9689-8f8e02ce3508" />
</details>



### Чек-лист
- [x] Изменения протестированы локально (домен успешно обрабатывается winws.exe)
- [x] Внесен только один необходимый домен без лишнего мусора
