### PR TITLE
Update list-exclude.txt

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -91,3 +91,4 @@ tbank.ru
 tochka-tech.com
 tochka.com
 vtb.ru
+steamcommunity.com


### PR DESCRIPTION
добавлен домен `steamcommunity.com` в список исключений, без него ломается авторизация через Steam OpenID (обнаружено при авторизации на scrap.tf)