### PR TITLE
Add Figma domains to general list

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -47,3 +47,4 @@ betterttv.net
 7tv.io
 localizeapi.com
 klipy.com
+figma.com


### PR DESCRIPTION
Adds figma.com and related domains (www, s3-alpha-sig, static) to the general list so Figma works behind DPI.