### PR TITLE
Align test analytics output

### DIFF
--- a/utils/test zapret.ps1
+++ b/utils/test zapret.ps1
@@ -838,13 +838,18 @@ try {
 
     Write-Host ""
     Write-Host "=== ANALYTICS ===" -ForegroundColor Cyan
+    $maxConfigLen = ($analytics.Keys | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum
     foreach ($config in $analytics.Keys) {
         $a = $analytics[$config]
+        $configPadded = $config.PadRight($maxConfigLen)
         if ($a.ContainsKey('PingOK')) {
-            Write-Host "$config : HTTP OK: $($a.OK), ERR: $($a.ERROR), UNSUP: $($a.UNSUP), Ping OK: $($a.PingOK), Fail: $($a.PingFail)" -ForegroundColor Yellow
+            $line = "{0} : HTTP OK: {1,3}, ERR: {2,3}, UNSUP: {3,3}, Ping OK: {4,3}, Fail: {5,3}" -f `
+                $configPadded, $a.OK, $a.ERROR, $a.UNSUP, $a.PingOK, $a.PingFail
         } else {
-            Write-Host "$config : OK: $($a.OK), FAIL: $($a.FAIL), UNSUP: $($a.UNSUPPORTED), BLOCKED: $($a.LIKELY_BLOCKED)" -ForegroundColor Yellow
+            $line = "{0} : OK: {1,3}, FAIL: {2,3}, UNSUP: {3,3}, BLOCKED: {4,3}" -f `
+                $configPadded, $a.OK, $a.FAIL, $a.UNSUPPORTED, $a.LIKELY_BLOCKED
         }
+        Write-Host $line -ForegroundColor Yellow
     }
 
     # Determine best strategy
@@ -916,13 +921,18 @@ try {
 
     # Add analytics
     Add-Content $resultFile "=== ANALYTICS ==="
+    $maxConfigLen = ($analytics.Keys | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum
     foreach ($config in $analytics.Keys) {
         $a = $analytics[$config]
+        $configPadded = $config.PadRight($maxConfigLen)
         if ($a.ContainsKey('PingOK')) {
-            Add-Content $resultFile "$config : HTTP OK: $($a.OK), ERR: $($a.ERROR), UNSUP: $($a.UNSUP), Ping OK: $($a.PingOK), Fail: $($a.PingFail)"
+            $line = "{0} : HTTP OK: {1,3}, ERR: {2,3}, UNSUP: {3,3}, Ping OK: {4,3}, Fail: {5,3}" -f `
+                $configPadded, $a.OK, $a.ERROR, $a.UNSUP, $a.PingOK, $a.PingFail
         } else {
-            Add-Content $resultFile "$config : OK: $($a.OK), FAIL: $($a.FAIL), UNSUP: $($a.UNSUPPORTED), BLOCKED: $($a.LIKELY_BLOCKED)"
+            $line = "{0} : OK: {1,3}, FAIL: {2,3}, UNSUP: {3,3}, BLOCKED: {4,3}" -f `
+                $configPadded, $a.OK, $a.FAIL, $a.UNSUPPORTED, $a.LIKELY_BLOCKED
         }
+        Add-Content $resultFile $line
     }
 
     Add-Content $resultFile "Best strategy: $bestConfig"


### PR DESCRIPTION
### Что изменено

Добавлено форматирование вывода информации после теста всех конфигов в `utils/test zapret.ps1`, как для вывода в консоль, так и для вывода в файл.

### Зачем

Сейчас результаты тестов сложнее сравнивать визуально, особенно когда названия конфигов имеют разную длину. Выравнивание делает вывод результата в консоли и в файле более наглядным.

### Пример

#### Было
```
=== ANALYTICS ===
general (ALT11).bat : OK: 94, FAIL: 12, UNSUP: 0, BLOCKED: 0
general (ALT3).bat : OK: 52, FAIL: 49, UNSUP: 0, BLOCKED: 3
general (FAKE TLS AUTO).bat : OK: 26, FAIL: 74, UNSUP: 0, BLOCKED: 6
general (ALT6).bat : OK: 0, FAIL: 106, UNSUP: 0, BLOCKED: 0
general (ALT5).bat : OK: 25, FAIL: 15, UNSUP: 0, BLOCKED: 68
general (SIMPLE FAKE ALT).bat : OK: 84, FAIL: 16, UNSUP: 0, BLOCKED: 6
general (FAKE TLS AUTO ALT3).bat : OK: 52, FAIL: 43, UNSUP: 0, BLOCKED: 9
general (ALT10).bat : OK: 94, FAIL: 12, UNSUP: 0, BLOCKED: 0
general (FAKE TLS AUTO ALT).bat : OK: 0, FAIL: 106, UNSUP: 0, BLOCKED: 0
general.bat : OK: 0, FAIL: 98, UNSUP: 0, BLOCKED: 6
general (ALT7).bat : OK: 31, FAIL: 16, UNSUP: 0, BLOCKED: 59
general (ALT4).bat : OK: 86, FAIL: 18, UNSUP: 0, BLOCKED: 2
general (FAKE TLS AUTO ALT2).bat : OK: 0, FAIL: 106, UNSUP: 0, BLOCKED: 0
general (ALT2).bat : OK: 0, FAIL: 104, UNSUP: 0, BLOCKED: 0
general (ALT8).bat : OK: 1, FAIL: 104, UNSUP: 0, BLOCKED: 1
general (ALT12).bat : OK: 94, FAIL: 12, UNSUP: 0, BLOCKED: 0
general (ALT9).bat : OK: 86, FAIL: 17, UNSUP: 0, BLOCKED: 3
general (ALT).bat : OK: 94, FAIL: 12, UNSUP: 0, BLOCKED: 0
general (SIMPLE FAKE).bat : OK: 76, FAIL: 27, UNSUP: 0, BLOCKED: 3
general (SIMPLE FAKE ALT2).bat : OK: 88, FAIL: 15, UNSUP: 0, BLOCKED: 3

Best config: general (ALT11).bat
```

#### Стало
```
=== ANALYTICS ===
general (ALT11).bat              : OK:  94, FAIL:  12, UNSUP:   0, BLOCKED:   0
general (ALT3).bat               : OK:  52, FAIL:  49, UNSUP:   0, BLOCKED:   3
general (FAKE TLS AUTO).bat      : OK:  26, FAIL:  80, UNSUP:   0, BLOCKED:   0
general (ALT6).bat               : OK:   0, FAIL: 103, UNSUP:   0, BLOCKED:   1
general (ALT5).bat               : OK:  25, FAIL:  14, UNSUP:   0, BLOCKED:  69
general (SIMPLE FAKE ALT).bat    : OK:  88, FAIL:  18, UNSUP:   0, BLOCKED:   0
general (FAKE TLS AUTO ALT3).bat : OK:  58, FAIL:  44, UNSUP:   0, BLOCKED:   2
general (ALT10).bat              : OK:  94, FAIL:  12, UNSUP:   0, BLOCKED:   0
general (FAKE TLS AUTO ALT).bat  : OK:   1, FAIL: 103, UNSUP:   0, BLOCKED:   0
general.bat                      : OK:   0, FAIL: 106, UNSUP:   0, BLOCKED:   0
general (ALT7).bat               : OK:  31, FAIL:  16, UNSUP:   0, BLOCKED:  59
general (ALT4).bat               : OK:  93, FAIL:  14, UNSUP:   0, BLOCKED:   1
general (FAKE TLS AUTO ALT2).bat : OK:   0, FAIL: 100, UNSUP:   0, BLOCKED:   0
general (ALT2).bat               : OK:   0, FAIL: 106, UNSUP:   0, BLOCKED:   0
general (ALT8).bat               : OK:   0, FAIL: 106, UNSUP:   0, BLOCKED:   0
general (ALT12).bat              : OK:  94, FAIL:  14, UNSUP:   0, BLOCKED:   0
general (ALT9).bat               : OK:  86, FAIL:  17, UNSUP:   0, BLOCKED:   3
general (ALT).bat                : OK:  94, FAIL:  12, UNSUP:   0, BLOCKED:   0
general (SIMPLE FAKE).bat        : OK:  94, FAIL:  12, UNSUP:   0, BLOCKED:   0
general (SIMPLE FAKE ALT2).bat   : OK:  94, FAIL:  12, UNSUP:   0, BLOCKED:   0

Best config: general (ALT11).bat
```