### PR TITLE
Добавить music.apple.com и mzstatic.com (cdn эпла) в list-exclude.

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -92,3 +92,5 @@ tochka-tech.com
 tochka.com
 vtb.ru
 steamcommunity.com
+music.apple.com
+mzstatic.com


### PR DESCRIPTION
По вечерам проявляется странная проблема в Apple Music, то обложки прогружаются (в 64х64), но обложки 512х512 выдают ERR_CONNECTION_RESET. Пофиксилось добавлением в list-exclude.

Конечно я не видел еще ни одного issue с данной проблемой. Вероятно, большинство людей не пользуются таким сервисом, либо же не замечают данной проблемы.




