### PR TITLE
Добавление OneDrive в list-exclude

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -18,6 +18,7 @@ habr.com
 microsoft.com
 microsoftonline.com
 live.com
+sharepoint.com
 minecraft.net
 xboxlive.com
 akamaitechnologies.com


### PR DESCRIPTION
Добавление в исключения домен `sharepoint.com` для работы OneDrive.

Данная проблема возникала при использовании `IPSet Filter` на `loaded`