### PR TITLE
Add figma.com to exclude list

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -110,3 +110,4 @@ tochka-tech.com
 tochka.com
 vtb.ru
 steamcommunity.com
+figma.com


### PR DESCRIPTION
## Проблема
figma.com не запускается через запрет без добавления в список исключений. Приложение не может подключиться.

## Решение
Добавил figma.com в `list-exclude.txt`

## Проверка
Протестировано локально - после добавления в список figma работает корректно.

## Влияние
Пользователи смогут использовать Figma через запрет без дополнительной настройки.