### PR TITLE
Добавить очистку кэша Discord PTB в service.bat

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -676,37 +676,13 @@ if !found_any_conflict!==1 (
 
 :: Discord cache clearing
 set "CHOICE="
-set /p "CHOICE=Do you want to clear the Discord cache? (Y/N) (default: Y)  "
+set /p "CHOICE=Do you want to clear the Discord and Discord PTB cache? (Y/N) (default: Y) "
 if "!CHOICE!"=="" set "CHOICE=Y"
 if "!CHOICE!"=="y" set "CHOICE=Y"
 
 if /i "!CHOICE!"=="Y" (
-    tasklist /FI "IMAGENAME eq Discord.exe" | findstr /I "Discord.exe" > nul
-    if !errorlevel!==0 (
-        echo Discord is running, closing...
-        taskkill /IM Discord.exe /F > nul
-        if !errorlevel! == 0 (
-            call :PrintGreen "Discord was successfully closed"
-        ) else (
-            call :PrintRed "Unable to close Discord"
-        )
-    )
-
-    set "discordCacheDir=%appdata%\discord"
-
-    for %%d in ("Cache" "Code Cache" "GPUCache") do (
-        set "dirPath=!discordCacheDir!\%%~d"
-        if exist "!dirPath!" (
-            rd /s /q "!dirPath!"
-            if !errorlevel!==0 (
-                call :PrintGreen "Successfully deleted !dirPath!"
-            ) else (
-                call :PrintRed "Failed to delete !dirPath!"
-            )
-        ) else (
-            call :PrintRed "!dirPath! does not exist"
-        )
-    )
+    call :clear_discord_cache "Discord.exe" "Discord" "%APPDATA%\discord"
+    call :clear_discord_cache "DiscordPTB.exe" "Discord PTB" "%APPDATA%\discordptb"
 )
 echo:
 
@@ -1017,6 +993,40 @@ exit /b
 
 
 :: Utility functions
+
+:clear_discord_cache
+setlocal EnableDelayedExpansion
+set "discordProcess=%~1"
+set "discordName=%~2"
+set "discordCacheDir=%~3"
+
+tasklist /FI "IMAGENAME eq !discordProcess!" 2>nul | findstr /I /C:"!discordProcess!" >nul
+if !errorlevel! equ 0 (
+    echo !discordName! is running, closing...
+    taskkill /IM "!discordProcess!" /F >nul 2>&1
+    if !errorlevel! equ 0 (
+        call :PrintGreen "!discordName! was successfully closed"
+    ) else (
+        call :PrintRed "Unable to close !discordName!"
+    )
+)
+
+if exist "!discordCacheDir!\" (
+    for %%d in ("Cache" "Code Cache" "GPUCache") do (
+        set "dirPath=!discordCacheDir!\%%~d"
+        if exist "!dirPath!\" (
+            rd /s /q "!dirPath!" >nul 2>&1
+            if exist "!dirPath!\" (
+                call :PrintRed "Failed to delete !dirPath!"
+            ) else (
+                call :PrintGreen "Successfully deleted !dirPath!"
+            )
+        )
+    )
+)
+
+endlocal
+exit /b
 
 :PrintGreen
 powershell -NoProfile -Command "Write-Host \"%~1\" -ForegroundColor Green"

--- a/service.bat
+++ b/service.bat
@@ -681,8 +681,17 @@ if "!CHOICE!"=="" set "CHOICE=Y"
 if "!CHOICE!"=="y" set "CHOICE=Y"
 
 if /i "!CHOICE!"=="Y" (
-    call :clear_discord_cache "Discord.exe" "Discord" "%APPDATA%\discord"
-    call :clear_discord_cache "DiscordPTB.exe" "Discord PTB" "%APPDATA%\discordptb"
+    set "discordFound=0"
+    if exist "%APPDATA%\discord\" (
+        set "discordFound=1"
+        call :clear_discord_cache "Discord.exe" "Discord" "%APPDATA%\discord"
+    )
+    if exist "%APPDATA%\discordptb\" (
+        set "discordFound=1"
+        call :clear_discord_cache "DiscordPTB.exe" "Discord PTB" "%APPDATA%\discordptb"
+    )
+    if !discordFound! equ 0 call :PrintRed "Discord and Discord PTB were not found"
+    set "discordFound="
 )
 echo:
 
@@ -1021,6 +1030,8 @@ if exist "!discordCacheDir!\" (
             ) else (
                 call :PrintGreen "Successfully deleted !dirPath!"
             )
+        ) else (
+            call :PrintRed "!dirPath! does not exist"
         )
     )
 )


### PR DESCRIPTION
Добавил очистку кэша Discord PTB в `service.bat`.

Скрипт закрывает `DiscordPTB.exe` и удаляет `Cache`, `Code Cache` и `GPUCache`.

Проверил вручную, всё отработало нормально.


<img width="673" height="167" alt="изображение" src="https://github.com/user-attachments/assets/26d4dbce-c1f3-4dd4-94d4-68b8c126aeb7" />
