### PR TITLE
service.bat: добавлена очистка кэша Discord Canary и Discord Development

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -678,7 +678,7 @@ if !found_any_conflict!==1 (
 
 :: Discord cache clearing
 set "CHOICE="
-set /p "CHOICE=Do you want to clear the Discord and Discord PTB cache? (Y/N) (default: Y) "
+set /p "CHOICE=Do you want to clear the Discord cache (Stable, PTB, Canary, Development)? (Y/N) (default: Y) "
 if "!CHOICE!"=="" set "CHOICE=Y"
 if "!CHOICE!"=="y" set "CHOICE=Y"
 
@@ -692,7 +692,15 @@ if /i "!CHOICE!"=="Y" (
         set "discordFound=1"
         call :clear_discord_cache "DiscordPTB.exe" "Discord PTB" "%APPDATA%\discordptb"
     )
-    if !discordFound! equ 0 call :PrintRed "Discord and Discord PTB were not found"
+    if exist "%APPDATA%\discordcanary\" (
+        set "discordFound=1"
+        call :clear_discord_cache "DiscordCanary.exe" "Discord Canary" "%APPDATA%\discordcanary"
+    )
+    if exist "%APPDATA%\discorddevelopment\" (
+        set "discordFound=1"
+        call :clear_discord_cache "DiscordDevelopment.exe" "Discord Development" "%APPDATA%\discorddevelopment"
+    )
+    if !discordFound! equ 0 call :PrintRed "Discord installations were not found"
     set "discordFound="
 )
 echo:


### PR DESCRIPTION

Добавлена поддержка очистки кэша для Discord Canary и Discord Development в разделе `Run Diagnostics` (`service.bat`).

Ранее очищался кэш только для Discord (Stable) и Discord PTB, при этом Discord имеет ещё две официальные сборки клиента:
- Discord Canary (`DiscordCanary.exe` → `%APPDATA%\discordcanary`)
- Discord Development (`DiscordDevelopment.exe` → `%APPDATA%\discorddevelopment`)

Пользователи этих версий не могли очистить кэш через диагностику, что могло приводить к проблемам с подключением после смены стратегии.

 Изменения

- Добавлены проверки и вызовы `clear_discord_cache` для `discordcanary` и `discorddevelopment`
- Обновлен текст промпта: `"Discord and Discord PTB"` → `"Discord cache (Stable, PTB, Canary, Development)"`
- Обновлено сообщение об ошибке: `"Discord and Discord PTB were not found"` → `"Discord installations were not found"`

 Тестирование

- Код следует тому же паттерну, что и существующие блоки для Discord Stable и Discord PTB
- Функция `clear_discord_cache` универсальна и принимает параметры (процесс, имя, путь) — новые вызовы используют корректные значения для Canary и Development
