### PR TITLE
service.bat: добавлены проверки cFosSpeed, ASUS GameFirst и Nahimic в диагностику

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -524,6 +524,36 @@ if !errorlevel!==0 (
 )
 echo:
 
+:: cFosSpeed
+sc query | findstr /I "cFos" > nul
+if !errorlevel!==0 (
+    call :PrintRed "[X] cFosSpeed services found. cFosSpeed conflicts with zapret"
+    call :PrintRed "Try to uninstall or disable cFosSpeed through services.msc"
+) else (
+    call :PrintGreen "cFosSpeed check passed"
+)
+echo:
+
+:: ASUS GameFirst
+sc query | findstr /I "GameFirst" > nul
+if !errorlevel!==0 (
+    call :PrintRed "[X] ASUS GameFirst services found. GameFirst conflicts with zapret"
+    call :PrintRed "Try to uninstall or disable GameFirst through services.msc"
+) else (
+    call :PrintGreen "ASUS GameFirst check passed"
+)
+echo:
+
+:: Nahimic
+sc query | findstr /I "Nahimic" > nul
+if !errorlevel!==0 (
+    call :PrintYellow "[?] Nahimic services found. Nahimic may cause network conflicts with zapret"
+    call :PrintYellow "If you experience issues, try to disable Nahimic through services.msc"
+) else (
+    call :PrintGreen "Nahimic check passed"
+)
+echo:
+
 :: WinDivert64.sys file
 set "BIN_PATH=%~dp0bin\"
 if not exist "%BIN_PATH%\*.sys" (


### PR DESCRIPTION
### Описание

Добавлены проверки на конфликтующие сетевые сервисы в `service.bat` → `Run Diagnostics`:

- **cFosSpeed** — сетевой оптимайзер, перехватывает трафик на уровне драйвера и конфликтует с WinDivert
- **ASUS GameFirst** — оптимайзер трафика для игр, встроен в материнские платы ASUS ROG, конфликтует с WinDivert
- **Nahimic** — аудиосервис MSI/Lenovo, известен сетевыми конфликтами (добавлен как предупреждение, а не ошибка)

### Обоснование

В диагностике уже есть проверки на Killer, SmartByte, Check Point и Intel Connectivity. 
Пользователи с этими сетевыми оптимайзерами часто сталкиваются с проблемами, но не понимают причину — диагностика им не подсказывает.

### Детали реализации

- cFosSpeed и GameFirst выводятся как `[X]` (красный) — подтверждённые конфликты
- Nahimic выводится как `[?]` (жёлтый) — возможный конфликт, рекомендация отключить при проблемах
- Паттерн кода идентичен существующим проверкам (Killer, SmartByte и др.)
