### PR TITLE
Добавление элементов в issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,8 @@ body:
       options:
         - label: Я искал решение проблемы в [README](https://github.com/Flowseal/zapret-discord-youtube/blob/main/README.md) и среди [Issues](https://github.com/Flowseal/zapret-discord-youtube/issues)
         - label: Я скачал ``zapret-discord-youtube`` из [релизов официального репозитория](https://github.com/Flowseal/zapret-discord-youtube/releases)
+        - label: Ознакомился с [условиями создания issue](https://github.com/ControlRe/zapret-discord-youtube/issues/2)
+          required: true
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,16 @@ body:
       placeholder: Описание проблемы
     validations:
       required: true
-
+  
+  - type: textarea
+    id: providerandregion
+    attributes:
+      label: Укажите своего провайдера и регион
+      description: Провайдер и регион на котором вы словили проблему
+      placeholder: Провайдер и регион
+    validations:
+      required: true
+  
   - type: textarea
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       options:
         - label: Я искал решение проблемы в [README](https://github.com/Flowseal/zapret-discord-youtube/blob/main/README.md) и среди [Issues](https://github.com/Flowseal/zapret-discord-youtube/issues)
         - label: Я скачал ``zapret-discord-youtube`` из [релизов официального репозитория](https://github.com/Flowseal/zapret-discord-youtube/releases)
-        - label: Ознакомился с [условиями создания Issue](https://github.com/ControlRe/zapret-discord-youtube/issues/2)
+        - label: Ознакомился с [условиями создания Issue](https://gist.github.com/ControlRe/af8f5ae80816af2ff4ffa9228bbaf626)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,11 +27,9 @@ body:
   - type: textarea
     id: providerandregion
     attributes:
-      label: Укажите своего провайдера и регион
+      label: Укажите своего провайдера и регион (при желании)
       description: Провайдер и регион на котором вы словили проблему
       placeholder: Провайдер и регион
-    validations:
-      required: true
   
   - type: textarea
     id: version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
       label: ⚠️ Чеклист
       description: Перед созданием нового Issue, удостоверьтесь что выполнили следующие пункты
       options:
-        - label: Я искал решение проблемы в [README](https://github.com/Flowseal/zapret-discord-youtube/blob/main/README.md) и среди [Issues](https://github.com/Flowseal/zapret-discord-youtube/issues)
+        - label: Я искал решение проблемы в [README](https://github.com/Flowseal/zapret-discord-youtube/blob/main/README.md) и среди [Issues](https://github.com/Flowseal/zapret-discord-youtube/issues) и [Discussions](https://github.com/Flowseal/zapret-discord-youtube/discussions)
         - label: Я скачал ``zapret-discord-youtube`` из [релизов официального репозитория](https://github.com/Flowseal/zapret-discord-youtube/releases)
         - label: Ознакомился с [условиями создания Issue](https://gist.github.com/ControlRe/af8f5ae80816af2ff4ffa9228bbaf626)
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       options:
         - label: Я искал решение проблемы в [README](https://github.com/Flowseal/zapret-discord-youtube/blob/main/README.md) и среди [Issues](https://github.com/Flowseal/zapret-discord-youtube/issues)
         - label: Я скачал ``zapret-discord-youtube`` из [релизов официального репозитория](https://github.com/Flowseal/zapret-discord-youtube/releases)
-        - label: Ознакомился с [условиями создания issue](https://github.com/ControlRe/zapret-discord-youtube/issues/2)
+        - label: Ознакомился с [условиями создания Issue](https://github.com/ControlRe/zapret-discord-youtube/issues/2)
           required: true
 
   - type: textarea


### PR DESCRIPTION
Добавлено два элемента:

### Один чекбокс с обязательной галочкой
В данном чекбоксе содержится ссылка на "правила" https://gist.github.com/ControlRe/af8f5ae80816af2ff4ffa9228bbaf626. Цель: снизить лишнее количество issues, которые открываются людьми от балды. Сделать первый чекбокс обязательным нельзя из-за ленивого отношения к заполняемым пунктам. А так есть шанс, что человек перед оформлением захочет поинтересоваться с чем он соглашается. Ещё имеется некоторая мысль в данном направлении. Если данный чекбокс уменьшит количество лишних issue, будет убрано значение required и поднимется обсуждение логики для проверки заполнения(т.е если человек не ознакомился, то оно будет автоматически закрыто. Данная логика может будет реализована в виде actions или добавится в модбота самим flowseal)

### Текстовое поле для указания провайдера и региона

Предложили идею в данном issue https://github.com/Flowseal/zapret-discord-youtube/issues/16397#issuecomment-5143471977. Цель: более точно разбираться с проблемой возникаемой у человека. Причина: часто люди не указывают провайдера и регион в следствие чего сложно понять характер проблемы