### PR TITLE
Добавить i.scdn.co для обложек Spotify в Discord

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -40,6 +40,7 @@ discordpartygames.com
 discordsays.com
 discordsez.com
 discordstatus.com
+i.scdn.co
 frankerfacez.com
 ffzap.com
 betterttv.net


### PR DESCRIPTION
Добавлен домен `i.scdn.co`, с которого Discord загружает обложки треков для интеграции со Spotify.

Без обработки этого домена обложки Spotify в профилях и активности Discord не загружаются. После добавления `i.scdn.co` в `list-general.txt` обложки начинают загружаться корректно.

<img width="652" height="224" alt="image" src="https://github.com/user-attachments/assets/22196017-08d6-4430-8c2e-1610b5a91aae" />

