### PR TITLE
Обновление диагностики

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -413,6 +413,9 @@ goto menu
 chcp 437 > nul
 cls
 
+:: Zapret path
+call :PrintGreen "Zapret installed in: '%~dp0'"
+
 :: Base Filtering Engine
 sc query BFE | findstr /I "RUNNING" > nul
 if !errorlevel!==0 (
@@ -520,8 +523,8 @@ echo:
 :: EasyAntiCheat
 sc query | findstr /I "EasyAntiCheat" > nul
 if !errorlevel!==0 (
-    call :PrintRed "[X] EasyAntiCheat services found. EasyAntiCheat conflicts with zapret"
-    call :PrintRed "Try to close game with EasyAntiCheat"
+    call :PrintYellow "[?] EasyAntiCheat services found. EasyAntiCheat conflicts with zapret"
+    call :PrintYellow "Try to close game with EasyAntiCheat"
 ) else (
     call :PrintGreen "EasyAntiCheat check passed"
 )
@@ -540,8 +543,8 @@ echo:
 :: OneDrive
 echo %~dp0\ | findstr /I /C:"%OneDrive%\\" > nul
 if !errorlevel!==0 (
-    call :PrintYellow "[?] Path where zapret is installed located in OneDrive"
-    call :PrintYellow "If bypass doesn't work, try to install zapret to another directory, for example in C:\zapret"
+    call :PrintRed "[X] Path where zapret is installed located in OneDrive"
+    call :PrintRed "If bypass doesn't work, try to install zapret to another directory, for example in C:\zapret"
 ) else (
     call :PrintGreen "OneDrive check passed"
 )

--- a/service.bat
+++ b/service.bat
@@ -531,10 +531,21 @@ echo:
 powershell -NoProfile -Command "if ('%~dp0' -match '[\u0430-\u044F\u0410-\u042F\u0451\u0401]') { exit 0 } else { exit 1 }"
 if !errorlevel!==0 (
     call :PrintYellow "[?] Path where zapret is installed contains Cyrillic characters"
-    call :PrintYellow "If bypass doesn't work, try to install zapret to another directory"
+    call :PrintYellow "If bypass doesn't work, try to install zapret to another directory, for example in C:\zapret"
 ) else (
-    call :PrintGreen "Cyrillic check passed"
+    call :PrintGreen "Cyrillic path check passed"
 )
+echo:
+
+:: OneDrive
+echo %~dp0\ | findstr /I /C:"%OneDrive%\\" > nul
+if !errorlevel!==0 (
+    call :PrintYellow "[?] Path where zapret is installed located in OneDrive"
+    call :PrintYellow "If bypass doesn't work, try to install zapret to another directory, for example in C:\zapret"
+) else (
+    call :PrintGreen "OneDrive check passed"
+)
+echo:
 
 :: WinDivert64.sys file
 set "BIN_PATH=%~dp0bin\"

--- a/service.bat
+++ b/service.bat
@@ -521,16 +521,6 @@ if !errorlevel!==0 (
 )
 echo:
 
-:: EasyAntiCheat
-sc query | findstr /I "EasyAntiCheat" > nul
-if !errorlevel!==0 (
-    call :PrintYellow "[?] EasyAntiCheat services found. EasyAntiCheat conflicts with zapret"
-    call :PrintYellow "Try to close game with EasyAntiCheat"
-) else (
-    call :PrintGreen "EasyAntiCheat check passed"
-)
-echo:
-
 :: Cyrillic path
 powershell -NoProfile -Command "if ('%~dp0' -match '[\u0430-\u044F\u0410-\u042F\u0451\u0401]') { exit 0 } else { exit 1 }"
 if !errorlevel!==0 (

--- a/service.bat
+++ b/service.bat
@@ -415,6 +415,7 @@ cls
 
 :: Zapret path
 call :PrintGreen "Zapret installed in: '%~dp0'"
+echo:
 
 :: Base Filtering Engine
 sc query BFE | findstr /I "RUNNING" > nul

--- a/service.bat
+++ b/service.bat
@@ -531,7 +531,7 @@ echo:
 powershell -NoProfile -Command "if ('%~dp0' -match '[\u0430-\u044F\u0410-\u042F\u0451\u0401]') { exit 0 } else { exit 1 }"
 if !errorlevel!==0 (
     call :PrintYellow "[?] Path where zapret is installed contains Cyrillic characters"
-    call :PrintRed "If bypass doesn't work, try to install zapret to another directory"
+    call :PrintYellow "If bypass doesn't work, try to install zapret to another directory"
 ) else (
     call :PrintGreen "Cyrillic check passed"
 )

--- a/service.bat
+++ b/service.bat
@@ -517,6 +517,25 @@ if !errorlevel!==0 (
 )
 echo:
 
+:: EasyAntiCheat
+sc query | findstr /I "EasyAntiCheat" > nul
+if !errorlevel!==0 (
+    call :PrintRed "[X] EasyAntiCheat services found. EasyAntiCheat conflicts with zapret"
+    call :PrintRed "Try to close game with EasyAntiCheat"
+) else (
+    call :PrintGreen "EasyAntiCheat check passed"
+)
+echo:
+
+:: Cyrillic path
+powershell -NoProfile -Command "if ('%~dp0' -match '[\u0430-\u044F\u0410-\u042F\u0451\u0401]') { exit 0 } else { exit 1 }"
+if !errorlevel!==0 (
+    call :PrintRed "[X] Path where zapret is installed contains Cyrillic characters"
+    call :PrintRed "Try to install zapret to another directory"
+) else (
+    call :PrintGreen "Cyrillic check passed"
+)
+
 :: WinDivert64.sys file
 set "BIN_PATH=%~dp0bin\"
 if not exist "%BIN_PATH%\*.sys" (

--- a/service.bat
+++ b/service.bat
@@ -530,8 +530,8 @@ echo:
 :: Cyrillic path
 powershell -NoProfile -Command "if ('%~dp0' -match '[\u0430-\u044F\u0410-\u042F\u0451\u0401]') { exit 0 } else { exit 1 }"
 if !errorlevel!==0 (
-    call :PrintRed "[X] Path where zapret is installed contains Cyrillic characters"
-    call :PrintRed "Try to install zapret to another directory"
+    call :PrintYellow "[?] Path where zapret is installed contains Cyrillic characters"
+    call :PrintRed "If bypass doesn't work, try to install zapret to another directory"
 ) else (
     call :PrintGreen "Cyrillic check passed"
 )


### PR DESCRIPTION
1. Добавил проверку на содержание кириллицы в пути установки zapret. Сделал через коды UTF-8 (`\u0430-\u044F\u0410-\u042F\u0451\u0401`) (`а-яА-ЯёЁ`) чтобы лишний раз не менять кодировку
2. Добавил проверку на OneDrive
3. Добавил вывод полного пути, где установлен zapret