### PR TITLE
Update list-exclude.txt (steam fix)

### DIFF
--- a/lists/list-exclude.txt
+++ b/lists/list-exclude.txt
@@ -109,4 +109,5 @@ t-bank-app.ru
 tochka-tech.com
 tochka.com
 vtb.ru
+api.steampowered.com
 steamcommunity.com


### PR DESCRIPTION
Срочный фикс для Steam. 
По какой-то причине Steam стал тормозить с включенным `ipset loaded`. 
Тормозит вход в Steam и запуск игры. 

Пример:
https://github.com/Flowseal/zapret-discord-youtube/issues/16728