### PR TITLE
Исправление загрузки Discord

### DIFF
--- a/.service/hosts
+++ b/.service/hosts
@@ -45,6 +45,10 @@
 162.159.137.232 discord.com
 162.159.128.233 discord.com
 162.159.135.232 discord.com
+162.159.138.232 updates.discord.com
+162.159.137.232 updates.discord.com
+162.159.128.233 updates.discord.com
+162.159.135.232 updates.discord.com
 
 104.25.158.178 finland10000.discord.media
 104.25.158.178 finland10001.discord.media

--- a/.service/hosts
+++ b/.service/hosts
@@ -41,6 +41,11 @@
 149.154.167.220 zws2.web.telegram.org
 149.154.167.220 zws4-1.web.telegram.org
 
+162.159.138.232 discord.com
+162.159.137.232 discord.com
+162.159.128.233 discord.com
+162.159.135.232 discord.com
+
 104.25.158.178 finland10000.discord.media
 104.25.158.178 finland10001.discord.media
 104.25.158.178 finland10002.discord.media


### PR DESCRIPTION
Один из IP Cloudflare которым пользуется Discord - `162.159.136.232`, был наглухо заблокирован по TCP и UDP в обе стороны на ТСПУ. Этот PR чинит бесконечный запуск дискорда либо долгий запуск в 3-5 минут пока Discord одумается попытаться подключится по другому IP из DNS. IP брались через RIPE Stats.
1 - https://stat.ripe.net/resource/discord.com#tab=dns
2 - https://stat.ripe.net/resource/updates.discord.com#tab=dns

<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/e4908ee8-0ca0-4543-8412-e2b53e3a8e0e" />
