### PR TITLE
service.bat: make curl fail in case of errors

### DIFF
--- a/service.bat
+++ b/service.bat
@@ -999,9 +999,9 @@ echo Updating ipset-all...
 if exist "%SystemRoot%\System32\curl.exe" (
     curl --version | find "libcurl/7"
     if !errorlevel!==0 (
-        curl --ssl-no-revoke -L -o "%listFile%" "%url%"
+        curl --ssl-no-revoke -L -f -o "%listFile%" "%url%"
     ) else (
-        curl --ssl-revoke-best-effort -L -o "%listFile%" "%url%"
+        curl --ssl-revoke-best-effort -L -f -o "%listFile%" "%url%"
     )
 ) else (
     powershell -NoProfile -Command ^
@@ -1035,7 +1035,7 @@ set "requestUrl=%hostsUrl%?t=%cacheBuster%"
 echo Checking hosts file...
 
 if exist "%SystemRoot%\System32\curl.exe" (
-    curl -L -s -o "%tempFile%" "%requestUrl%"
+    curl -L -s -f -o "%tempFile%" "%requestUrl%"
 ) else (
     powershell -NoProfile -Command ^
         "$url = '%requestUrl%';" ^


### PR DESCRIPTION
Добавлен -f / --fail для вызова curl 

Без опции -f curl заменяет файл на HTTP body, даже если получен HTTP status code 4xx, 5xx
С опцией -f не заменяет содержимое файла при получении ошибок от веб-сервера

Данная проблема обнаружена @Dmitriy224 с помощью ИИ: https://github.com/Flowseal/zapret-discord-youtube/issues/17212 